### PR TITLE
fix: adjust API Reference  navigation

### DIFF
--- a/app/components/Api/Navigation.vue
+++ b/app/components/Api/Navigation.vue
@@ -70,7 +70,7 @@ const navigationData = computed(() => {
 
   return [{
     title: 'API Reference',
-    children: items.concat(singleItems)
+    children: singleItems.concat(items)
   }]
 })
 


### PR DESCRIPTION
place ungrouped menus at the top