### PR TITLE
docs(model_backend): sync LLM/embedder backends and defaults

### DIFF
--- a/content/en/open_source/modules/model_backend.md
+++ b/content/en/open_source/modules/model_backend.md
@@ -8,22 +8,26 @@ MemOS decouples **model logic** from **runtime config** via two Pydantic factori
 
 | Factory | Produces | Typical backends |
 |---------|----------|------------------|
-| `LLMFactory` | Chat‑completion model | `ollama`, `openai`, `qwen`, `deepseek`, `huggingface` |
-| `EmbedderFactory` | Text‑to‑vector encoder | `ollama`, `sentence_transformer`, `universal_api` |
+| `LLMFactory` | Chat model | `ollama`, `openai`, `azure`, `qwen`, `deepseek`, `huggingface`, `huggingface_singleton`, `vllm`, `openai_new` |
+| `EmbedderFactory` | Text embedder | `ollama`, `sentence_transformer`, `ark`, `universal_api` |
 
-Both factories accept a `*_ConfigFactory(model_validate(...))` blob, so you can switch provider with a single `backend=` swap.
+Both factories accept a `*_ConfigFactory.model_validate(...)` blob, so you can switch provider with a single `backend=` swap.
 
 
 ## LLM Module <a id="llm-module"></a>
 
 ### Supported LLM Backends <a id="supported-llm-backends"></a>
-| Backend       | Notes | Example Model Id                          |
-|---------------|-------|-------------------------------------------|
-| `ollama`  | Local llama‑cpp runner | `qwen3:0.6b` etc.                         |
-| `openai`      | Official or proxy | `gpt-4o-mini`, `gpt-3.5-turbo` etc.       |
-| `qwen`        | DashScope‑compatible | `qwen-plus`, `qwen-max-2025-01-25`  etc.  |
-| `deepseek`    | DeepSeek REST API | `deepseek-chat`, `deepseek-reasoner` etc. |
-| `huggingface` | Transformers pipeline | `Qwen/Qwen3-1.7B`  etc.                       |
+| Backend | Notes | Example model_name_or_path |
+|---|---|---|
+| `ollama` | Local Ollama server | `qwen3:0.6b` |
+| `openai` | OpenAI-compatible Chat Completions | `gpt-4.1-nano` |
+| `azure` | Azure OpenAI Chat Completions | `<your-deployment-name>` |
+| `qwen` | DashScope OpenAI-compatible API | `qwen-plus` |
+| `deepseek` | DeepSeek OpenAI-compatible API | `deepseek-chat` / `deepseek-reasoner` |
+| `huggingface` | Local transformers pipeline | `Qwen/Qwen3-1.7B` |
+| `huggingface_singleton` | Same as `huggingface` + singleton reuse | `Qwen/Qwen3-1.7B` |
+| `vllm` | OpenAI-compatible vLLM server | `Qwen/Qwen2.5-7B-Instruct` |
+| `openai_new` | OpenAI Responses API wrapper | `gpt-4.1` |
 
 ### LLM Config Schema <a id="llm-config-schema"></a>
 
@@ -33,11 +37,11 @@ Common fields:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model_name_or_path` | str | – | Model id or local tag |
-| `temperature` | float | 0.8 |
-| `max_tokens` | int | 1024 |
-| `top_p` / `top_k` | float / int | 0.9 / 50 |
+| `temperature` | float | 0.7 |
+| `max_tokens` | int | 8192 |
+| `top_p` / `top_k` | float / int | 0.95 / 50 |
 | *API‑specific* | e.g. `api_key`, `api_base` | – | OpenAI‑compatible creds |
-| `remove_think_prefix` | bool | True | Strip `/think` role content |
+| `remove_think_prefix` | bool | False | Remove content within think tags from the generated text |
 
 
 ### Factory Usage <a id="llm-factory-usage"></a>
@@ -77,17 +81,21 @@ Find all scenarios in `examples/basic_modules/llm.py`.
 ## Embedding Module <a id="embedding-module"></a>
 
 ### Supported Embedder Backends <a id="supported-embedder-backends"></a>
-| Backend | Example Model | Vector Dim |
-|---------|---------------|------------|
-| `ollama` | `nomic-embed-text:latest` | 768 |
-| `sentence_transformer` | `nomic-ai/nomic-embed-text-v1.5` | 768 |
-| `universal_api` | `text-embedding-3-large` | 3072 |
+| Backend | Notes | Example model_name_or_path |
+|---|---|---|
+| `ollama` | Local Ollama server | `nomic-embed-text:latest` |
+| `sentence_transformer` | Local sentence-transformers | `nomic-ai/nomic-embed-text-v1.5` |
+| `ark` | Volcano Engine Ark embeddings | `<ark-model-id>` |
+| `universal_api` | Universal provider wrapper (e.g. OpenAI) | `text-embedding-3-large` |
 
 ### Embedder Config Schema <a id="embedder-config-schema"></a>
 Shared keys: `model_name_or_path`, optional API creds (`api_key`, `base_url`), etc.
 
 ### Factory Usage <a id="embedder-factory-usage"></a>
 ```python
+from memos.configs.embedder import EmbedderConfigFactory
+from memos.embedders.factory import EmbedderFactory
+
 cfg = EmbedderConfigFactory.model_validate({
     "backend": "ollama",
     "config": {"model_name_or_path": "nomic-embed-text:latest"}


### PR DESCRIPTION
## Summary
Update the LLM/Embedder documentation to match the current MemOS code (supported backends, factory usage, and config defaults).

## Changes
- Updated `content/en/open_source/modules/model_backend.md`:
  - Listed supported LLM backends from `LLMFactory` (incl. `azure`, `vllm`, `openai_new`, `huggingface_singleton`)
  - Listed supported embedder backends from `EmbedderFactory` (incl. `ark`)
  - Fixed the `.model_validate(...)` wording and added missing imports in the embedder usage snippet
  - Synced common config defaults with `BaseLLMConfig`

## Verification
- [x] All referenced classes exist in code (Check 1)
- [x] Import paths verified (Check 2)
- [x] Method signatures match code (Check 3)
- [x] Config fields match code (Check 4)
- [ ] API endpoints match code (Check 5, if applicable)

## Cross-Language
- [ ] Chinese (`content/cn/`) counterpart checked
- Needs follow-up: update `content/cn/open_source/modules/model_backend.md` (if present)

## Code Reference
Based on MemOS commit: `84028f25f06ba6b4e45a3d109109da47d0c847a8`
