### PR TITLE
docs: rename OpenClaw to Agent and add Hermes local plugin docs

### DIFF
--- a/content/cn/openclaw/examples/hermes_usage.md
+++ b/content/cn/openclaw/examples/hermes_usage.md
@@ -1,0 +1,208 @@
+---
+title: Hermes 本地插件使用
+desc: MemOS Hermes 本地插件的 API 工具、团队共享和多智能体使用示例。
+---
+
+## 基本使用
+
+安装完成后，运行 `hermes chat` 即可开始对话。每轮对话自动存入记忆，可通过 `http://127.0.0.1:18901` 访问 Memory Viewer 查看和管理。
+
+```bash
+hermes chat
+```
+
+### 验证记忆功能
+
+1. 与 Hermes Agent 进行任意对话。
+2. 打开 Memory Viewer（`http://127.0.0.1:18901`），确认对话内容已出现在记忆列表中。
+3. 新开一个对话，让 Agent 回忆之前的内容：
+
+```
+你：你还记得我之前让你帮我处理过什么事情吗？
+Agent：（调用 memory_search）是的，我们之前讨论过……
+```
+
+---
+
+## API 工具
+
+Hermes 插件通过以下工具与 Agent 交互，Agent 可在对话中按需调用。
+
+### memory_search — 记忆搜索
+
+参数：`query`（必填），`maxResults`（默认 20），`minScore`（默认 0.45），`role`。
+
+返回 excerpts（原文片段）+ chunkId / task_id，不含 summary；经 LLM 相关性过滤。
+
+```text
+Agent 调用示例：
+  memory_search(query="Nginx 部署配置")
+  → 返回相关记忆片段，附带 chunkId 和 task_id
+```
+
+### memory_get — 获取记忆原文
+
+通过 `chunkId` 获取记忆块完整原文。可选 `maxChars` 限制返回长度。
+
+### memory_timeline — 上下文邻居
+
+以 `chunkId` 为锚点，获取前后相邻的记忆块。参数 `window` 默认 2。
+
+### task_summary — 任务摘要
+
+通过 `taskId` 或 `query` 获取任务结构化摘要（目标/步骤/结果/关键细节）。
+
+```text
+Agent 调用示例：
+  memory_search(query="数据库迁移") → 返回 task_id: "task_42"
+  task_summary(taskId="task_42") → 返回完整的结构化任务摘要
+```
+
+### skill_get / skill_install — 技能获取与安装
+
+- `skill_get` 支持 `skillId` 或 `taskId`（按任务解析技能）
+- `skill_install` 将技能安装到工作区
+
+### memory_write_public — 写入公共记忆
+
+写入公共记忆（owner="public"），所有 Agent 均可检索。参数 `content`（必填），`summary`（可选）。
+
+### skill_search — 技能搜索
+
+搜索技能：FTS5 关键词 + 向量语义双通道，RRF 融合后经 LLM 判断相关性。
+
+参数：`query`（必填），`scope`（"mix" | "self" | "public"，默认 "mix"）。
+
+### skill_publish / skill_unpublish — 技能发布
+
+- `skill_publish` 将技能设为公开，其他 Agent 可通过 `skill_search` 发现并安装
+- `skill_unpublish` 设为私有
+
+### memory_viewer — Viewer URL
+
+返回 Memory Viewer 的访问地址。
+
+---
+
+## 团队共享
+
+Team Sharing 将多个 Hermes 实例连接为协作网络。一个实例作为 **Hub**（团队服务端），其他实例作为 **Client** 连接。私有数据始终留在本地，仅明确共享的任务、记忆和技能对团队可见。
+
+### 启动 Hub（团队服务端）
+
+在 Viewer 设置页面配置或通过 Bridge Config JSON：
+
+```json
+{
+  "sharing": {
+    "enabled": true,
+    "role": "hub",
+    "hub": {
+      "teamName": "My Team",
+      "teamToken": "${MEMOS_TEAM_TOKEN}"
+    }
+  }
+}
+```
+
+### 加入 Hub（客户端）
+
+```json
+{
+  "sharing": {
+    "enabled": true,
+    "role": "client",
+    "client": {
+      "hubAddress": "192.168.1.100:18902"
+    }
+  }
+}
+```
+
+::tip
+也可以通过 **Viewer → 设置 → 团队共享** 面板直接配置，无需手动编辑 JSON。
+::
+
+### 管理员功能
+
+| 功能 | 说明 |
+|------|------|
+| 审批加入 | 审批或拒绝待审用户 |
+| 提升/降级 | 提升成员为管理员或降级为普通成员；被操作用户收到通知 |
+| 移除成员 | 移除团队成员（带确认弹窗，不可移除自己） |
+| 团队概览 | 查看团队名称、总成员数、活跃成员数 |
+| Hub 关闭通知 | 关闭 Hub 时自动通知所有客户端 |
+
+### 团队共享 API 工具
+
+| Tool | 说明 |
+|------|------|
+| `task_share` / `task_unshare` | 将任务推送到 / 移除出团队 |
+| `skill_publish` / `skill_unpublish` | 发布 / 取消发布技能到团队 |
+| `network_memory_detail` | 获取团队记忆完整内容 |
+| `network_skill_pull` | 拉取团队技能到本地 |
+| `network_team_info` | 查看当前团队连接状态 |
+
+### 多实例部署
+
+同一台机器上可运行多个 Hermes 实例，端口和数据完全隔离：
+
+| 资源 | 隔离方式 | 示例 |
+|------|---------|------|
+| Viewer | MEMOS_VIEWER_PORT | 18901 / 18903 |
+| Daemon | MEMOS_DAEMON_PORT | 18992 / 18994 |
+| Database | MEMOS_STATE_DIR | ~/.hermes/memos-state/ / ~/hermes-work/memos-state/ |
+
+---
+
+## 多智能体协同
+
+MemOS 原生支持多 Agent 场景。每个 Agent 的记忆和任务通过 `owner` 字段隔离（Hermes 默认 owner 为 `hermes`），检索时自动过滤为当前 Agent + public。
+
+- **记忆隔离**：Agent A 无法检索 Agent B 的私有记忆
+- **公共记忆**：通过 `memory_write_public` 写入 owner="public" 的记忆，所有 Agent 可检索
+- **技能共享**：通过 `skill_publish` 将技能设为公开，其他 Agent 可通过 `skill_search` 发现并安装
+- **技能检索**：`skill_search` 支持 scope 参数（mix/self/public），FTS + 向量双通道 + RRF 融合 + LLM 相关性判断
+
+### 操作示例
+
+```text
+Agent Alpha:
+  memory_search("deploy config")
+  → 仅看到自己 + public 的记忆
+  memory_write_public("shared deploy config")
+  skill_publish("nginx-proxy") ✓ 现在是公共技能
+
+Agent Beta:
+  memory_search("alpha private deploy detail")
+  → 看不到 Alpha 的私有记忆
+  memory_search("shared deploy config")
+  → 找到公共记忆
+  skill_search("nginx deployment")
+  → 找到: nginx-proxy (public)
+  skill_install("nginx-proxy") ✓ 已安装
+```
+
+---
+
+## Viewer HTTP API
+
+Memory Viewer 提供以下 HTTP 接口：
+
+| Method | Path | 说明 |
+|--------|------|------|
+| GET | / | Memory Viewer HTML |
+| POST | /api/auth/* | setup / login / reset / logout |
+| GET | /api/memories | 记忆列表（分页、过滤） |
+| GET | /api/search | 混合搜索（向量 minScore 0.64 + FTS5 降级） |
+| POST/PUT/DELETE | /api/memory/:id | 记忆 CRUD |
+| GET | /api/tasks | 任务列表（状态过滤） |
+| GET/PUT/DELETE | /api/task/:id | 任务详情/编辑/删除 |
+| POST | /api/task/:id/retry-skill | 重试技能生成 |
+| GET | /api/skills | 技能列表 |
+| GET/PUT/DELETE | /api/skill/:id | 技能详情/编辑/删除 |
+| PUT | /api/skill/:id/visibility | 设置公开/私有 |
+| GET | /api/skill/:id/download | 技能 ZIP 下载 |
+| GET | /api/stats, /api/metrics | 统计与分析 |
+| GET | /api/logs | 工具调用日志 |
+| GET/PUT | /api/config | 在线配置 |

--- a/content/cn/openclaw/hermes_local_plugin.md
+++ b/content/cn/openclaw/hermes_local_plugin.md
@@ -1,0 +1,254 @@
+---
+title: Hermes 本地插件
+desc: 为 Hermes Agent 提供完全本地化的持久记忆、智能任务总结、技能自动进化和多智能体协同。
+---
+
+MemOS Hermes 本地插件为 **Hermes Agent** 提供完全本地化的持久记忆能力。所有数据存储在本机 SQLite（`~/.hermes/memos-state/`），零云依赖。Viewer 仅监听 127.0.0.1，密码保护。
+
+## 核心特性
+
+| 特性 | 说明 |
+|------|------|
+| 💾 全量记忆写入 | 每次对话自动捕获，语义分片后持久化。 |
+| ⚡ 任务总结与技能进化 | 碎片对话归纳为结构化任务，再提炼为可复用技能并持续升级。 |
+| 🔍 混合检索 | FTS5 + 向量，RRF，MMR，时间衰减。 |
+| 🧠 全量可视化 | 记忆/任务/技能/分析/日志/导入/设置 7 个管理页。 |
+| 💰 分级模型 | Embedding/摘要/技能可独立配置不同模型。 |
+| 🤝 多智能体协同 | 记忆隔离 + 公共记忆 + 技能共享，多 Agent 协同进化。 |
+| 🐍 Python 原生集成 | 通过 MemoryProvider 接口原生集成 Hermes Agent，无需额外配置网关。 |
+| 👥 团队共享中心 | Hub-Client 架构，跨实例共享记忆/任务/技能。审批流程、角色管理、实时通知。 |
+| 🔗 LLM 智能降级 | 技能模型 → 摘要模型 → Hermes 原生模型三级自动降级，零手动干预。 |
+
+---
+
+## 系统架构
+
+Hermes Agent 通过 Python MemoryProvider 接口与 MemOS 桥接守护进程通信。四条流水线：记忆写入 → 任务总结与技能进化（异步）→ 智能检索 → 协同共享。每个 Agent 拥有独立记忆空间，通过公共记忆和技能共享实现协同进化。
+
+```
+流水线 1：写入
+Hermes Agent → Bridge Daemon (TCP :18992) → Ingest (chunk→summary→embed→dedup) → SQLite+FTS5
+
+流水线 2：任务 & 技能（异步）
+Task Processor (话题检测 → 摘要) → Skill Evolver (评估 → 生成/升级)
+
+流水线 3：自动召回
+prefetch (auto-recall) → Recall (FTS+Vector) → LLM filter → Inject context
+
+流水线 4：按需检索
+Agent (memory_search) → RRF→MMR→Decay → LLM filter → excerpts+chunkId/task_id
+→ task_summary / skill_get / memory_timeline
+```
+
+### 数据流
+
+#### 写入
+1. `sync_turn` → Bridge Daemon → Chunk → LLM Summary → Embed → Dedup → Store
+2. 异步：任务检测 → 任务摘要 → 技能评估 → 技能生成/升级
+
+#### 检索
+1. 每轮自动：`prefetch` 用用户消息检索 → LLM 过滤相关 → 注入 system 上下文；无结果时提示 agent 自生成 query 调 `memory_search`。
+2. `memory_search` → FTS5+Vector → RRF → MMR → Decay → LLM filter → excerpts + chunkId/task_id
+3. `task_summary` / `skill_get`(skillId|taskId) / `memory_timeline`(chunkId) / `skill_install`
+
+---
+
+## 快速开始
+
+### 前置条件
+
+- **Node.js** ≥ 18
+- **Python 3**
+- **Hermes Agent** 已安装（`~/.hermes/hermes-agent` 或本地仓库）
+- Embedding / Summarizer API 可选，不配自动用本地模型
+
+### Step 1：一键安装（推荐）
+
+一条命令完成所有安装，无需手动操作：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash
+```
+
+#### 通过 npm 安装
+
+```bash
+mkdir -p ~/.hermes/memos-plugin && cd ~/.hermes/memos-plugin && npm pack @memtensor/memos-local-hermes-plugin && tar xzf *.tgz && mv package/* . && rm -rf package *.tgz && bash install.sh
+```
+
+::note
+安装器做了什么？ 自动检测并安装 Node.js（如缺失）→ 从 npm 下载插件包 → 安装依赖 → 创建 `memtensor` 软链接到 Hermes 插件目录 → 更新 `~/.hermes/config.yaml` → 验证插件加载 → 启动 Bridge 守护进程和 Memory Viewer。
+::
+
+::warning
+安装失败？最常见的问题是 `better-sqlite3` 原生模块编译失败。确保已安装编译工具链（`gcc`, `make`, `python3`）。在 Ubuntu/Debian 上：`apt install build-essential`。
+::
+
+### Step 2：开始使用
+
+```bash
+hermes chat
+```
+
+安装脚本会自动启动 Memory Viewer。之后每次运行 `hermes chat`，daemon 会自动拉起（如果尚未运行）。退出 hermes 后 daemon 继续后台运行。
+
+::tip
+安装后每次对话自动存入记忆。访问 `http://127.0.0.1:18901` 查看 Memory Viewer。
+::
+
+### Step 3：配置
+
+**两种方式**：编辑 `~/.hermes/config.yaml` 或通过 Viewer 网页面板在线修改。支持分级模型。
+
+#### 基本配置 (config.yaml)
+
+```yaml
+# ~/.hermes/config.yaml
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: memtensor
+```
+
+#### 模型分级配置（通过环境变量）
+
+```bash
+# Embedding — 轻量模型
+export MEMOS_EMBEDDING_PROVIDER="openai_compatible"
+export MEMOS_EMBEDDING_API_KEY="sk-••••••"
+export MEMOS_EMBEDDING_ENDPOINT="https://your-api-endpoint/v1"
+
+# 自定义端口
+export MEMOS_DAEMON_PORT=18992
+export MEMOS_VIEWER_PORT=18901
+
+# 自定义数据目录
+export MEMOS_STATE_DIR="/custom/path/memos-state"
+```
+
+#### 高级配置（通过 Bridge 配置 JSON）
+
+```bash
+export MEMOS_BRIDGE_CONFIG='{
+  "stateDir": "~/.hermes/memos-state",
+  "config": {
+    "embedding": {
+      "provider": "openai_compatible",
+      "model": "bge-m3",
+      "endpoint": "https://your-api-endpoint/v1",
+      "apiKey": "sk-••••••"
+    },
+    "summarizer": {
+      "provider": "openai_compatible",
+      "model": "gpt-4o-mini",
+      "endpoint": "https://your-api-endpoint/v1",
+      "apiKey": "sk-••••••"
+    },
+    "skillEvolution": {
+      "summarizer": {
+        "provider": "openai_compatible",
+        "model": "claude-4.6-opus",
+        "endpoint": "https://your-api-endpoint/v1",
+        "apiKey": "sk-••••••"
+      }
+    },
+    "recall": {
+      "vectorSearchMaxChunks": 0
+    },
+    "viewerPort": 18901
+  }
+}'
+```
+
+---
+
+## 模块
+
+### Capture
+通过 `sync_turn` 接口捕获每轮 user/assistant 消息，通过 `on_memory_write` 捕获用户画像更新。经 Bridge 守护进程传入 Ingest 管线。
+
+### Ingest
+异步队列：语义分片 → LLM 摘要 → 向量化 → 智能去重（Top-5 相似 + LLM 判 DUPLICATE/UPDATE/NEW，UPDATE 合并摘要并追加内容）→ 存储；演化块记录 merge_history。
+
+### 任务总结
+异步逐轮检测任务边界：分组为用户回合 → 第一条直接分配 → 后续每条由 LLM 判断话题是否切换（强偏向 SAME，避免过度分割）→ 2h 超时强制切分 → 结构化摘要（目标/步骤/结果）。支持编辑、删除、重试技能生成。
+
+### 技能进化
+规则过滤 → LLM 评估（可重复/有价值的任务才生成技能）→ SKILL.md 生成（步骤/警告/脚本）/ 升级 → 质量评分 → 安装。LLM 使用三级降级链（技能模型 → 摘要模型 → Hermes 原生模型）。支持编辑、删除、设为公开/私有。
+
+### Recall
+FTS5+Vector → RRF(k=60) → MMR(λ=0.7) → Decay(14d) → Normalize → Filter(≥0.45) → Top-K。自动关联 Task/Skill。
+
+### Viewer
+7 页：记忆 CRUD/搜索/演化标识、任务（对话气泡）、技能（版本/下载）、分析、日志（工具调用输入输出）、导入、在线配置。密码保护。默认端口 `18901`。
+
+---
+
+## 检索算法
+
+### RRF（倒数排名融合）
+
+$$\text{RRF}(d) = \sum_i \frac{1}{k + \text{rank}_i(d) + 1}$$
+
+### MMR（最大边际相关）
+
+$$\text{MMR}(d) = \lambda \cdot \text{rel}(d) - (1-\lambda) \cdot \max \text{sim}(d, d_s)$$
+
+### 时间衰减
+
+$$\text{final} = \text{score} \times \bigl(0.3 + 0.7 \times 0.5^{t/14}\bigr)$$
+
+---
+
+## LLM 降级链
+
+所有 LLM 调用（摘要、话题检测、去重、技能生成/升级）均使用三级自动降级机制：
+
+```
+skillSummarizer（技能专用模型，可选）→ summarizer（通用摘要模型）→ Hermes Native（自动检测）
+```
+
+- 每一级失败后自动尝试下一级，无需手动干预
+- `skillSummarizer` 未配置时直接跳到 `summarizer`
+- 如果所有模型均失败，回退到规则方法（无 LLM）或跳过该步骤
+
+---
+
+## 环境变量
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `MEMOS_STATE_DIR` | `~/.hermes/memos-state` | 记忆数据库位置 |
+| `MEMOS_DAEMON_PORT` | `18992` | Bridge 守护进程 TCP 端口 |
+| `MEMOS_VIEWER_PORT` | `18901` | Memory Viewer HTTP 端口 |
+| `MEMOS_EMBEDDING_PROVIDER` | `local` | Embedding 提供商 |
+| `MEMOS_EMBEDDING_API_KEY` | — | Embedding API 密钥 |
+| `MEMOS_EMBEDDING_ENDPOINT` | — | 自定义 Embedding 端点 |
+| `MEMOS_BRIDGE_CONFIG` | — | 完整 Bridge 配置 JSON |
+| `MEMOS_BRIDGE_SCRIPT` | — | Bridge 脚本路径覆盖 |
+| `HERMES_HOME` | `~/.hermes` | Hermes 主目录 |
+
+---
+
+## 默认值
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| maxResults | 6 (max 20) | 默认返回数 |
+| minScore (tool) | 0.45 | memory_search 最低分 |
+| minScore (viewer) | 0.64 | Viewer 搜索向量阈值 |
+| rrfK | 60 | RRF 融合常数 |
+| mmrLambda | 0.7 | MMR 相关性 vs 多样性 |
+| recencyHalfLife | 14d | 时间衰减半衰期 |
+| vectorSearchMaxChunks | 0 (all) | 0=搜索全部；大库可设 200k-300k |
+| dedup threshold | 0.75 | 语义去重余弦相似度 |
+| viewerPort | 18901 | Memory Viewer |
+| daemonPort | 18992 | Bridge Daemon TCP |
+| owner | hermes | 记忆归属标识 |
+| taskIdle | 2h | 任务空闲超时 |
+
+---
+
+## 更多资料
+
+- [GitHub](https://github.com/MemTensor/MemOS/tree/main/apps/memos-local-plugin)

--- a/content/cn/settings.yml
+++ b/content/cn/settings.yml
@@ -93,15 +93,17 @@ nav:
     - "(ri:robot-line) Agent开发":
       - "(ri:book-open-line) 使用指南": mcp_agent/agent/guide.md
 
-  - "(ri:robot-line) Openclaw":
+  - "(ri:robot-line) Agent":
     - "(ri:book-open-line) 云插件 vs 本地插件": openclaw/plugin_compare.md
     - "(ri:file-list-3-line) 更新日志": openclaw/changes.md
     - "(ri:download-line) 安装指南": 
       - "(ri:cloud-line) OpenClaw 云插件": openclaw/guide.md
       - "(ri:computer-line) OpenClaw 本地插件": openclaw/local_plugin.md
+      - "(ri:server-line) Hermes 本地插件": openclaw/hermes_local_plugin.md
     - "(ri:flask-line) 使用示例": 
       - "(ri:team-line) 多智能体记忆隔离": openclaw/examples/multi_agent.md
       - "(ri:filter-3-line) 记忆召回的二次过滤": openclaw/examples/recall_filter.md
+      - "(ri:terminal-box-line) Hermes 本地插件使用": openclaw/examples/hermes_usage.md
 
   - "(ri:file-code-line) API文档":
     - "(ri:rocket-line) 开始使用":

--- a/content/en/openclaw/examples/hermes_usage.md
+++ b/content/en/openclaw/examples/hermes_usage.md
@@ -1,0 +1,208 @@
+---
+title: Hermes Local Plugin Usage
+desc: API tools, team sharing, and multi-agent usage examples for the MemOS Hermes local plugin.
+---
+
+## Basic Usage
+
+After installation, run `hermes chat` to start a conversation. Every turn is auto-stored in memory. Visit `http://127.0.0.1:18901` to access the Memory Viewer for management.
+
+```bash
+hermes chat
+```
+
+### Verify Memory is Working
+
+1. Have a conversation with your Hermes Agent about anything.
+2. Open the Memory Viewer at `http://127.0.0.1:18901` and check that the conversation appears.
+3. In a new conversation, ask the agent to recall what you discussed:
+
+```
+You: Do you remember what I asked you to help me with before?
+Agent: (Calls memory_search) Yes, we previously discussed...
+```
+
+---
+
+## API Tools
+
+The Hermes plugin provides the following tools for Agent interaction. The Agent can call them on demand during conversations.
+
+### memory_search — Memory Search
+
+Parameters: `query` (required), `maxResults` (default 20), `minScore` (default 0.45), `role`.
+
+Returns excerpts + chunkId/task_id, no summary; LLM relevance filter applied.
+
+```text
+Agent call example:
+  memory_search(query="Nginx deployment config")
+  → Returns relevant memory excerpts with chunkId and task_id
+```
+
+### memory_get — Get Full Memory Text
+
+Retrieves the full original text of a memory chunk by `chunkId`. Optional `maxChars` to limit response length.
+
+### memory_timeline — Context Neighbors
+
+Gets neighboring memory chunks around a `chunkId` anchor. Parameter `window` defaults to 2.
+
+### task_summary — Task Summary
+
+Gets structured task summary (goal/steps/result/key details) by `taskId` or `query`.
+
+```text
+Agent call example:
+  memory_search(query="database migration") → returns task_id: "task_42"
+  task_summary(taskId="task_42") → returns full structured task summary
+```
+
+### skill_get / skill_install — Skill Get & Install
+
+- `skill_get` accepts `skillId` or `taskId` (resolves skill by task)
+- `skill_install` installs the skill to workspace
+
+### memory_write_public — Write Public Memory
+
+Writes public memory (owner="public"), discoverable by all agents. Parameters: `content` (required), `summary` (optional).
+
+### skill_search — Skill Search
+
+Searches skills via FTS5 + vector dual channel, RRF fusion, then LLM relevance judgment.
+
+Parameters: `query` (required), `scope` ("mix" | "self" | "public", default "mix").
+
+### skill_publish / skill_unpublish — Skill Publish
+
+- `skill_publish` makes a skill public and discoverable via `skill_search`
+- `skill_unpublish` sets it private
+
+### memory_viewer — Viewer URL
+
+Returns the Memory Viewer access URL.
+
+---
+
+## Team Sharing
+
+Team Sharing connects multiple Hermes instances into a collaborative network. One instance serves as the **Hub** (team server) while others connect as **Clients**. Private data stays local — only explicitly shared tasks, memories, and skills are visible to the team.
+
+### Start a Hub (Team Server)
+
+Configure via Viewer settings page or Bridge Config JSON:
+
+```json
+{
+  "sharing": {
+    "enabled": true,
+    "role": "hub",
+    "hub": {
+      "teamName": "My Team",
+      "teamToken": "${MEMOS_TEAM_TOKEN}"
+    }
+  }
+}
+```
+
+### Join a Hub (Client)
+
+```json
+{
+  "sharing": {
+    "enabled": true,
+    "role": "client",
+    "client": {
+      "hubAddress": "192.168.1.100:18902"
+    }
+  }
+}
+```
+
+::tip
+You can also configure sharing through the **Viewer → Settings → Team Sharing** panel without editing JSON.
+::
+
+### Admin Features
+
+| Feature | Description |
+|---------|-------------|
+| Approve/Reject | Approve or reject pending members |
+| Promote/Demote | Promote members to admin or demote to regular member; affected users receive notifications |
+| Remove Member | Remove team members (with confirmation, self-removal prevented) |
+| Team Overview | View team name, total members, active member count |
+| Shutdown Notify | All clients notified automatically when Hub shuts down |
+
+### Team Sharing API Tools
+
+| Tool | Description |
+|------|-------------|
+| `task_share` / `task_unshare` | Push task to / remove from team |
+| `skill_publish` / `skill_unpublish` | Publish / unpublish skill to team |
+| `network_memory_detail` | Fetch full team memory content |
+| `network_skill_pull` | Pull team skill bundle locally |
+| `network_team_info` | Show current team connection state |
+
+### Multi-Instance Deployment
+
+Run multiple Hermes instances on the same machine with full isolation:
+
+| Resource | Isolation | Example |
+|----------|-----------|---------|
+| Viewer | MEMOS_VIEWER_PORT | 18901 / 18903 |
+| Daemon | MEMOS_DAEMON_PORT | 18992 / 18994 |
+| Database | MEMOS_STATE_DIR | ~/.hermes/memos-state/ / ~/hermes-work/memos-state/ |
+
+---
+
+## Multi-Agent Collaboration
+
+MemOS natively supports multi-agent scenarios. Each agent's memories and tasks are isolated via an `owner` field (Hermes defaults to `hermes`); retrieval automatically filters to current agent + public.
+
+- **Memory Isolation**: Agent A cannot retrieve Agent B's private memories
+- **Public Memory**: Use `memory_write_public` to write owner="public" memories discoverable by all agents
+- **Skill Sharing**: Use `skill_publish` to make skills public; other agents discover and install via `skill_search`
+- **Skill Discovery**: `skill_search` supports scope (mix/self/public), FTS + vector dual channel + RRF fusion + LLM relevance judgment
+
+### Example Workflow
+
+```text
+Agent Alpha:
+  memory_search("deploy config")
+  → sees own + public memories only
+  memory_write_public("shared deploy config")
+  skill_publish("nginx-proxy") ✓ now public
+
+Agent Beta:
+  memory_search("alpha private deploy detail")
+  → no alpha private memories
+  memory_search("shared deploy config")
+  → found public memory
+  skill_search("nginx deployment")
+  → Found: nginx-proxy (public)
+  skill_install("nginx-proxy") ✓ installed
+```
+
+---
+
+## Viewer HTTP API
+
+The Memory Viewer provides the following HTTP endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | / | Memory Viewer HTML |
+| POST | /api/auth/* | setup / login / reset / logout |
+| GET | /api/memories | Memory list (pagination, filters) |
+| GET | /api/search | Hybrid search (vector minScore 0.64 + FTS5 fallback) |
+| POST/PUT/DELETE | /api/memory/:id | Memory CRUD |
+| GET | /api/tasks | Task list (status filter) |
+| GET/PUT/DELETE | /api/task/:id | Task detail/edit/delete |
+| POST | /api/task/:id/retry-skill | Retry skill generation |
+| GET | /api/skills | Skill list |
+| GET/PUT/DELETE | /api/skill/:id | Skill detail/edit/delete |
+| PUT | /api/skill/:id/visibility | Set public/private |
+| GET | /api/skill/:id/download | Download as ZIP |
+| GET | /api/stats, /api/metrics | Stats & metrics |
+| GET | /api/logs | Tool call logs |
+| GET/PUT | /api/config | Online configuration |

--- a/content/en/openclaw/hermes_local_plugin.md
+++ b/content/en/openclaw/hermes_local_plugin.md
@@ -1,0 +1,254 @@
+---
+title: Hermes Local Plugin
+desc: Fully local persistent memory, smart task summarization, auto skill evolution, and multi-agent collaboration for Hermes Agent.
+---
+
+The MemOS Hermes local plugin provides fully local persistent memory for **Hermes Agent**. All data is stored in local SQLite (`~/.hermes/memos-state/`), with zero cloud dependency. The Viewer only listens on 127.0.0.1 and is password-protected.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| 💾 Full-Write | Auto-captures every conversation, chunks semantically. |
+| ⚡ Tasks & Skills | Conversations organized into tasks, then distilled into skills that auto-upgrade. |
+| 🔍 Hybrid Search | FTS5 + vector, RRF, MMR, recency decay. |
+| 🧠 Visualization | 7 pages: memories, tasks, skills, analytics, logs, import, settings. |
+| 💰 Tiered Models | Each pipeline configurable with different models. |
+| 🤝 Multi-Agent | Memory isolation + public memory + skill sharing for collective evolution. |
+| 🐍 Python Native | Native integration via MemoryProvider interface for Hermes Agent, no gateway configuration needed. |
+| 👥 Team Sharing Hub | Hub-Client architecture for cross-instance sharing. Approval flow, role management, real-time notifications. |
+| 🔗 LLM Fallback Chain | Skill model → summarizer → Hermes native model, auto-fallback with zero manual intervention. |
+
+---
+
+## Architecture
+
+Hermes Agent communicates with the MemOS bridge daemon via the Python MemoryProvider interface. Four pipelines: write → task & skill evolution (async) → retrieval → collaboration. Each agent has isolated memory; public memory and skill sharing enable collective evolution.
+
+```
+Pipeline 1: Write
+Hermes Agent → Bridge Daemon (TCP :18992) → Ingest (chunk→summary→embed→dedup) → SQLite+FTS5
+
+Pipeline 2: Tasks & Skills (async)
+Task Processor (topic detect → summary) → Skill Evolver (eval → create/upgrade)
+
+Pipeline 3: Auto-recall
+prefetch (auto-recall) → Recall (FTS+Vector) → LLM filter → Inject context
+
+Pipeline 4: On-demand search
+Agent (memory_search) → RRF→MMR→Decay → LLM filter → excerpts+chunkId/task_id
+→ task_summary / skill_get / memory_timeline
+```
+
+### Data Flow
+
+#### Write
+1. `sync_turn` → Bridge Daemon → Chunk → LLM Summary → Embed → Dedup → Store
+2. Async: task detect → summary → skill eval → create/upgrade
+
+#### Read
+1. Per turn: `prefetch` searches with user message → LLM filters relevant → inject system context; if no hits, hint agent to call `memory_search` with self-generated query.
+2. `memory_search` → FTS5+Vector → RRF → MMR → Decay → LLM filter → excerpts + chunkId/task_id
+3. `task_summary` / `skill_get`(skillId|taskId) / `memory_timeline`(chunkId) / `skill_install`
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- **Node.js** ≥ 18
+- **Python 3**
+- **Hermes Agent** installed (`~/.hermes/hermes-agent` or local clone)
+- Embedding / Summarizer APIs optional, falls back to local
+
+### Step 1: One-Line Install (Recommended)
+
+One command does everything — no manual steps needed:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash
+```
+
+#### Install via npm
+
+```bash
+mkdir -p ~/.hermes/memos-plugin && cd ~/.hermes/memos-plugin && npm pack @memtensor/memos-local-hermes-plugin && tar xzf *.tgz && mv package/* . && rm -rf package *.tgz && bash install.sh
+```
+
+::note
+What does the installer do? Auto-detects and installs Node.js if missing → downloads plugin from npm → installs dependencies → creates `memtensor` symlink in Hermes plugins → updates `~/.hermes/config.yaml` → verifies plugin loading → starts bridge daemon and Memory Viewer.
+::
+
+::warning
+Install failed? The most common issue is `better-sqlite3` compilation failure. Ensure build toolchain is installed (`gcc`, `make`, `python3`). On Ubuntu/Debian: `apt install build-essential`.
+::
+
+### Step 2: Get Started
+
+```bash
+hermes chat
+```
+
+The installer automatically starts the Memory Viewer. Each time you run `hermes chat`, the daemon starts automatically (if not already running). It keeps running in the background after hermes exits.
+
+::tip
+Every conversation auto-stored. Visit `http://127.0.0.1:18901` for the Memory Viewer.
+::
+
+### Step 3: Configuration
+
+**Two methods**: edit `~/.hermes/config.yaml` or via Viewer web panel. Tiered models supported.
+
+#### Basic Config (config.yaml)
+
+```yaml
+# ~/.hermes/config.yaml
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: memtensor
+```
+
+#### Tiered Model Config (via Environment Variables)
+
+```bash
+# Embedding — lightweight model
+export MEMOS_EMBEDDING_PROVIDER="openai_compatible"
+export MEMOS_EMBEDDING_API_KEY="sk-••••••"
+export MEMOS_EMBEDDING_ENDPOINT="https://your-api-endpoint/v1"
+
+# Custom ports
+export MEMOS_DAEMON_PORT=18992
+export MEMOS_VIEWER_PORT=18901
+
+# Custom data directory
+export MEMOS_STATE_DIR="/custom/path/memos-state"
+```
+
+#### Advanced Config (via Bridge Config JSON)
+
+```bash
+export MEMOS_BRIDGE_CONFIG='{
+  "stateDir": "~/.hermes/memos-state",
+  "config": {
+    "embedding": {
+      "provider": "openai_compatible",
+      "model": "bge-m3",
+      "endpoint": "https://your-api-endpoint/v1",
+      "apiKey": "sk-••••••"
+    },
+    "summarizer": {
+      "provider": "openai_compatible",
+      "model": "gpt-4o-mini",
+      "endpoint": "https://your-api-endpoint/v1",
+      "apiKey": "sk-••••••"
+    },
+    "skillEvolution": {
+      "summarizer": {
+        "provider": "openai_compatible",
+        "model": "claude-4.6-opus",
+        "endpoint": "https://your-api-endpoint/v1",
+        "apiKey": "sk-••••••"
+      }
+    },
+    "recall": {
+      "vectorSearchMaxChunks": 0
+    },
+    "viewerPort": 18901
+  }
+}'
+```
+
+---
+
+## Modules
+
+### Capture
+Captures each user/assistant turn via `sync_turn`, user profile updates via `on_memory_write`. Forwarded to the Ingest pipeline through the bridge daemon.
+
+### Ingest
+Async queue: chunk → summary → embed → smart dedup (Top-5 similar + LLM DUPLICATE/UPDATE/NEW; UPDATE merges summary and appends content) → store; evolved chunks track merge_history.
+
+### Task Summarization
+Async per-turn boundary detection: group into user turns → first turn assigned directly → each subsequent turn checked by LLM topic judge (strongly biased toward SAME to avoid over-splitting) → 2h timeout forces split → structured summary (goal/steps/result). Supports edit, delete, retry skill generation.
+
+### Skill Evolution
+Rule filter → LLM evaluate (only repeatable/valuable tasks generate skills) → SKILL.md (steps/warnings/scripts) / upgrade → score → install. LLM uses a 3-level fallback chain (skill model → summarizer → Hermes native model). Supports edit, delete, toggle visibility.
+
+### Recall
+FTS5+Vector → RRF(k=60) → MMR(λ=0.7) → Decay(14d) → Normalize → Filter(≥0.45) → Top-K. Auto-links Task/Skill.
+
+### Viewer
+7 pages: memory CRUD/search/evolution badges, tasks (chat bubbles), skills (versions/download), analytics, logs (tool call I/O), import, online config. Password-protected. Default port `18901`.
+
+---
+
+## Retrieval Algorithms
+
+### RRF (Reciprocal Rank Fusion)
+
+$$\text{RRF}(d) = \sum_i \frac{1}{k + \text{rank}_i(d) + 1}$$
+
+### MMR (Maximal Marginal Relevance)
+
+$$\text{MMR}(d) = \lambda \cdot \text{rel}(d) - (1-\lambda) \cdot \max \text{sim}(d, d_s)$$
+
+### Recency Decay
+
+$$\text{final} = \text{score} \times \bigl(0.3 + 0.7 \times 0.5^{t/14}\bigr)$$
+
+---
+
+## LLM Fallback Chain
+
+All LLM calls (summary, topic detection, dedup, skill generation/upgrade) use a 3-level automatic fallback chain:
+
+```
+skillSummarizer (skill-dedicated, optional) → summarizer (general summarizer) → Hermes Native (auto-detected)
+```
+
+- Each level auto-falls back to the next on failure, zero manual intervention
+- If `skillSummarizer` is not configured, skips directly to `summarizer`
+- If all models fail, falls back to rule-based methods (no LLM) or skips the step
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMOS_STATE_DIR` | `~/.hermes/memos-state` | Memory database location |
+| `MEMOS_DAEMON_PORT` | `18992` | Bridge daemon TCP port |
+| `MEMOS_VIEWER_PORT` | `18901` | Memory Viewer HTTP port |
+| `MEMOS_EMBEDDING_PROVIDER` | `local` | Embedding provider |
+| `MEMOS_EMBEDDING_API_KEY` | — | Embedding API key |
+| `MEMOS_EMBEDDING_ENDPOINT` | — | Custom embedding endpoint |
+| `MEMOS_BRIDGE_CONFIG` | — | Full bridge config JSON |
+| `MEMOS_BRIDGE_SCRIPT` | — | Bridge script path override |
+| `HERMES_HOME` | `~/.hermes` | Hermes home directory |
+
+---
+
+## Defaults
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| maxResults | 6 (max 20) | Default result count |
+| minScore (tool) | 0.45 | memory_search minimum |
+| minScore (viewer) | 0.64 | Viewer search vector threshold |
+| rrfK | 60 | RRF fusion constant |
+| mmrLambda | 0.7 | MMR relevance vs diversity |
+| recencyHalfLife | 14d | Recency decay half-life |
+| vectorSearchMaxChunks | 0 (all) | 0=search all; set 200k-300k for large DBs |
+| dedup threshold | 0.75 | Semantic dedup cosine similarity |
+| viewerPort | 18901 | Memory Viewer |
+| daemonPort | 18992 | Bridge Daemon TCP |
+| owner | hermes | Memory ownership identifier |
+| taskIdle | 2h | Task idle timeout |
+
+---
+
+## More
+
+- [GitHub](https://github.com/MemTensor/MemOS/tree/main/apps/memos-local-plugin)

--- a/content/en/settings.yml
+++ b/content/en/settings.yml
@@ -86,15 +86,17 @@ nav:
     - "(ri:flask-line) Extraction Model":
       - "(ri:file-code-line) Usage Examples": self_developed_model/extraction_usage_example.md
 
-  - "(ri:robot-line) Openclaw":
+  - "(ri:robot-line) Agent":
     - "(ri:book-open-line) Cloud Plugin vs Local Plugin": openclaw/plugin_compare.md
     - "(ri:file-list-3-line) Changelog": openclaw/changes.md
     - "(ri:download-line) Installation Guide": 
       - "(ri:cloud-line) OpenClaw Cloud Plugin": openclaw/guide.md
       - "(ri:computer-line) OpenClaw Local Plugin": openclaw/local_plugin.md
+      - "(ri:server-line) Hermes Local Plugin": openclaw/hermes_local_plugin.md
     - "(ri:flask-line) Usage Examples": 
       - "(ri:team-line) Multi-Agent Memory Isolation": openclaw/examples/multi_agent.md
       - "(ri:filter-3-line) Secondary Filtering for Memory Recall": openclaw/examples/recall_filter.md
+      - "(ri:terminal-box-line) Hermes Local Plugin Usage": openclaw/examples/hermes_usage.md
 
   - "(ri:puzzle-line) MCP and Agent Framework Support":
     - "(ri:tools-line) MCP Services":

--- a/i18n/locales/cn.js
+++ b/i18n/locales/cn.js
@@ -10,7 +10,7 @@ export default {
       cloud: 'MemOS Cloud',
       openSource: '开源项目',
       selfDevelopedModel: '自研模型',
-      openclaw: 'OpenClaw',
+      openclaw: 'Agent',
       mcpAgent: 'MCP与Agent框架支持',
       apiDocs: 'API接口文档',
       samples: '示例项目',
@@ -55,7 +55,7 @@ export default {
     title: '别让你的 AI 再忘来忘去，用 MemOS',
     description: '在这里，你将找到从上手入门到生产部署的一切指南，帮助你在最短时间内把 MemOS 集成到你的 AI 应用中',
     buttonText: '现在就去',
-    openclawButton: 'OpenClaw 配置指南',
+    openclawButton: 'Agent 配置指南',
     items: [
       {
         title: 'MemOS Cloud',

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -10,7 +10,7 @@ export default {
       cloud: 'MemOS Cloud',
       openSource: 'Open Source',
       selfDevelopedModel: 'Self-developed Models',
-      openclaw: 'OpenClaw',
+      openclaw: 'Agent',
       mcpAgent: 'MCP & Agent Framework',
       apiDocs: 'API Documentation',
       samples: 'Sample Projects',
@@ -55,7 +55,7 @@ export default {
     title: 'Don\'t let your AI forget again, Empower it with MemOS!',
     description: 'Here, you\'ll find everything to quickly integrate MemOS into your AI applications and deploy it in production',
     buttonText: 'Get Started Now',
-    openclawButton: 'OpenClaw Configuration',
+    openclawButton: 'Agent Configuration',
     items: [
       {
         title: 'MemOS Cloud',


### PR DESCRIPTION
## Summary

- Rename "OpenClaw" to "Agent" in navigation tabs and i18n locales (cn/en)
- Add Hermes local plugin installation guide with full documentation (cn/en)
- Add Hermes local plugin usage examples covering API tools, team sharing, and multi-agent collaboration (cn/en)

## Changes

### Navigation
- `content/cn/settings.yml` / `content/en/settings.yml`: "Openclaw" → "Agent", added Hermes entries under Installation Guide and Usage Examples

### i18n
- `i18n/locales/cn.js` / `i18n/locales/en.js`: "OpenClaw" → "Agent" in header menu and homepage button

### New Files
- `content/cn/openclaw/hermes_local_plugin.md` — Hermes 本地插件安装指南（中文）
- `content/en/openclaw/hermes_local_plugin.md` — Hermes Local Plugin Installation Guide (English)
- `content/cn/openclaw/examples/hermes_usage.md` — Hermes 本地插件使用示例（中文）
- `content/en/openclaw/examples/hermes_usage.md` — Hermes Local Plugin Usage Examples (English)

## Test plan
- [ ] Verify navigation shows "Agent" instead of "OpenClaw"
- [ ] Verify Hermes local plugin pages render correctly in both cn/en
- [ ] Verify all internal links work properly