### PR TITLE
fix: only inject Clarity and GA scripts in production environment

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,15 +21,19 @@ const config: NuxtConfig = {
       script: [
         { src: 'https://cdn.memtensor.com.cn/file/js-cookie-3.0.5.min.js', type: 'text/javascript' },
         { src: 'https://cdn.memtensor.com.cn/file/locale.1.1.2.min.js', type: 'text/javascript' },
-        {
-          innerHTML: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wfn83tdrco");`,
-          type: 'text/javascript'
-        },
-        { src: 'https://www.googletagmanager.com/gtag/js?id=G-7J1J9RW0T1', async: true },
-        {
-          innerHTML: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-7J1J9RW0T1');`,
-          type: 'text/javascript'
-        }
+        ...(env === 'prod'
+          ? [
+              {
+                innerHTML: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wfn83tdrco");`,
+                type: 'text/javascript'
+              },
+              { src: 'https://www.googletagmanager.com/gtag/js?id=G-7J1J9RW0T1', async: true },
+              {
+                innerHTML: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-7J1J9RW0T1');`,
+                type: 'text/javascript'
+              }
+            ]
+          : [])
       ]
     }
   },


### PR DESCRIPTION
Wrap analytics scripts with env === 'prod' check to prevent data pollution from pre-release and dev environments.

Made-with: Cursor