### PR TITLE
fix: use runtime hostname check instead of build-time env check for a…

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,19 +21,10 @@ const config: NuxtConfig = {
       script: [
         { src: 'https://cdn.memtensor.com.cn/file/js-cookie-3.0.5.min.js', type: 'text/javascript' },
         { src: 'https://cdn.memtensor.com.cn/file/locale.1.1.2.min.js', type: 'text/javascript' },
-        ...(env === 'prod'
-          ? [
-              {
-                innerHTML: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wfn83tdrco");`,
-                type: 'text/javascript'
-              },
-              { src: 'https://www.googletagmanager.com/gtag/js?id=G-7J1J9RW0T1', async: true },
-              {
-                innerHTML: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-7J1J9RW0T1');`,
-                type: 'text/javascript'
-              }
-            ]
-          : [])
+        {
+          innerHTML: `(function(){var h=location.hostname;if(h.indexOf('-pre.')!==-1||h==='localhost')return;(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","wfn83tdrco");window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-7J1J9RW0T1');var s=document.createElement('script');s.async=1;s.src='https://www.googletagmanager.com/gtag/js?id=G-7J1J9RW0T1';document.head.appendChild(s);})();`,
+          type: 'text/javascript'
+        }
       ]
     }
   },


### PR DESCRIPTION
…nalytics

Check hostname at runtime in the browser to exclude pre-release and localhost, instead of relying on build-time env variable which may not be set correctly.

Made-with: Cursor