### PR TITLE
修复知识库文档中的语法错误

### DIFF
--- a/doc-agent-fix-suggestion.md
+++ b/doc-agent-fix-suggestion.md
@@ -1,0 +1,25 @@
+# Doc Agent 修复建议
+
+修复了知识库文档中的语法错误，替换了中文逗号为英文逗号，以确保 Python 解析器能够正确解析文档内容。
+
+## 暂未自动应用，建议人工处理：
+
+### `content/cn/memos_cloud/features/advanced/knowledge_base.md` (mode=line_replace)
+
+修正了中文逗号为英文逗号
+
+未应用原因：find 未匹配到当前文件内容
+
+**找到原文：**
+
+```text
+内网代理常见故障排查，
+```
+
+**替换为：**
+
+```text
+内网代理常见故障排查,
+```
+
+> 本文件由 Doc Agent 自动生成，请人工 review 后决定是否采纳。


### PR DESCRIPTION
修复了知识库文档中的语法错误，替换了中文逗号为英文逗号，以确保 Python 解析器能够正确解析文档内容。

---
> 这是 Doc Agent 自动起草的 **draft PR**，模式：`source_patch`。请 review 每个文件 diff，确认无误后再合并。
> 如有 patch 应用失败的文件，会在底部以「未应用 patches」附建议供人工处理。

---
## Doc Agent patches
### 未应用，请人工处理 (1)
- `content/cn/memos_cloud/features/advanced/knowledge_base.md` (line_replace) — find 未匹配到当前文件内容