### PR TITLE
fix: keep deploy working when release sync fails

### DIFF
--- a/scripts/fetch-releases.mjs
+++ b/scripts/fetch-releases.mjs
@@ -1,6 +1,8 @@
 import { writeFileSync, readFileSync, existsSync } from 'fs'
 import fetch from 'node-fetch'
 
+const targetPath = new URL('../content/releases.json', import.meta.url)
+
 function processReleases(data) {
   return data.map((release) => {
     // Extract what's changed section from body
@@ -86,8 +88,6 @@ async function fetchReleases() {
       versions: processedData
     }, null, 2)
 
-    const targetPath = new URL('../content/releases.json', import.meta.url)
-
     // Check if there are any new versions or changes
     if (existsSync(targetPath)) {
       const existingContent = readFileSync(targetPath, 'utf8')
@@ -104,6 +104,12 @@ async function fetchReleases() {
     console.log('Successfully generated releases data at content/releases.json')
   } catch (error) {
     console.error('Error processing releases:', error)
+
+    if (existsSync(targetPath)) {
+      console.warn('Using existing content/releases.json because release sync failed.')
+      return
+    }
+
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Summary

- Keep deployment builds running when GitHub release sync fails.
- Reuse the committed `content/releases.json` fallback if the MemOS Releases API request fails.
- Preserve the existing hard failure when no fallback release file exists.

## Verification

- Ran `pnpm run sync-releases` with GitHub API unreachable; it now exits successfully and logs that the existing `content/releases.json` is reused.

## Context

The gray deployment was failing with `ELIFECYCLE Command failed with exit code 1`. Locally, `pnpm run generate` reproduced the first hard failure in `scripts/fetch-releases.mjs` when `https://api.github.com/repos/MemTensor/MemOS/releases` could not be resolved.
