### PR TITLE
fix: resolve docs deployment warnings

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -15,10 +15,10 @@ const localeItems = computed(() => tm('homepage.items') as ItemProps[])
 
 useHead({ title: () => t('homepage.title') })
 const rawItems: HomeRouteItem[] = [
-  { to: '/memos_cloud/introduction/mem_production', icon: 'ri:brain-line' },
-  { to: '/memos_cloud/getting_started/quick_start', icon: 'ri:file-cloud-fill' },
-  { to: '/open_source/getting_started/installation', icon: 'ri:open-source-fill' },
-  { to: '/usecase/knowledge_qa_assistant', icon: 'ri:book-read-fill' },
+  { to: '/memos_cloud/introduction/mem_production', icon: 'i-ri-brain-line' },
+  { to: '/memos_cloud/getting_started/quick_start', icon: 'i-ri-file-cloud-fill' },
+  { to: '/open_source/getting_started/installation', icon: 'i-ri-open-source-fill' },
+  { to: '/usecase/knowledge_qa_assistant', icon: 'i-ri-book-read-fill' },
   { to: '/mcp_agent/mcp/guide', icon: 'material-symbols:switch-access-3' },
   { to: '/api_docs/start/overview', icon: 'ant-design:api-filled' }
 ]
@@ -53,14 +53,14 @@ const items = computed(() => localeItems.value.map((item, index) => ({
       <template #links>
         <BaseButton
           type="primary"
-          trailing-icon="ri:arrow-right-line"
+          trailing-icon="i-ri-arrow-right-line"
           :to="localePath('/memos_cloud/getting_started/quick_start')"
         >
           {{ $t('homepage.buttonText') }}
         </BaseButton>
         <BaseButton
           type="default"
-          trailing-icon="ri:arrow-right-line"
+          trailing-icon="i-ri-arrow-right-line"
           :to="localePath('/openclaw/guide')"
         >
           {{ $t('homepage.openclawButton') }}

--- a/content/cn/memos_cloud/getting_started/agent_usage.md
+++ b/content/cn/memos_cloud/getting_started/agent_usage.md
@@ -161,7 +161,7 @@ Claude Desktop、Cline、Chatbox 等客户端的配置方式类似，入口位�
 ::card-group
   :::card
   ---
-  icon: ri:puzzle-line
+  icon: i-ri-puzzle-line
   title: OpenClaw 云插件
 
   to: /cn/openclaw/guide
@@ -171,7 +171,7 @@ Claude Desktop、Cline、Chatbox 等客户端的配置方式类似，入口位�
 
   :::card
   ---
-  icon: ri:terminal-box-line
+  icon: i-ri-terminal-box-line
   title: MCP 使用指南
 
   to: /cn/mcp_agent/mcp/guide
@@ -181,7 +181,7 @@ Claude Desktop、Cline、Chatbox 等客户端的配置方式类似，入口位�
 
   :::card
   ---
-  icon: ri:file-code-line
+  icon: i-ri-file-code-line
   title: API / SDK
 
   to: /cn/memos_cloud/getting_started/quick_start

--- a/content/cn/memos_cloud/getting_started/overview.md
+++ b/content/cn/memos_cloud/getting_started/overview.md
@@ -43,7 +43,7 @@ MemOS 会在后台把原始信息加工成可检索的记忆内容，并持续�
 ::card-group
   :::card
   ---
-  icon: ri:rocket-line
+  icon: i-ri-rocket-line
   title: 快速开始
 
   to: /cn/memos_cloud/getting_started/quick_start
@@ -54,7 +54,7 @@ MemOS 会在后台把原始信息加工成可检索的记忆内容，并持续�
   :::card
   ---
 
-  icon: ri:brain-line
+  icon: i-ri-brain-line
   title: MemOS 工作原理
 
   to: /cn/memos_cloud/introduction/mem_production
@@ -66,7 +66,7 @@ MemOS 会在后台把原始信息加工成可检索的记忆内容，并持续�
 :::card
   ---
 
-  icon: ri:dashboard-line
+  icon: i-ri-dashboard-line
   title: 云服务与开源方案
 
   to: /cn/memos_cloud/getting_started/cloud_and_opensource
@@ -76,7 +76,7 @@ MemOS 会在后台把原始信息加工成可检索的记忆内容，并持续�
 
   :::card
   ---
-  icon: ri:robot-line
+  icon: i-ri-robot-line
   title: 在 Agent 中使用
 
   to: /cn/memos_cloud/getting_started/agent_usage

--- a/content/cn/memos_cloud/getting_started/quick_start.md
+++ b/content/cn/memos_cloud/getting_started/quick_start.md
@@ -239,7 +239,7 @@ MemOS 会自动召回【事实记忆：曾去过哪里】【偏好记忆：订�
 ::card-group
   :::card
   ---
-  icon: ri:checkbox-circle-line
+  icon: i-ri-checkbox-circle-line
   title: 核心操作
   to: /cn/memos_cloud/mem_operations/add_message
   ---
@@ -248,7 +248,7 @@ MemOS 会自动召回【事实记忆：曾去过哪里】【偏好记忆：订�
 
   :::card
   ---
-  icon: ri:robot-line
+  icon: i-ri-robot-line
   title: 在 Agent 中使用
 
   to: /cn/memos_cloud/getting_started/agent_usage
@@ -258,7 +258,7 @@ MemOS 会自动召回【事实记忆：曾去过哪里】【偏好记忆：订�
 
   :::card
   ---
-  icon: ri:file-code-line
+  icon: i-ri-file-code-line
   title: API 参考
 
   to: /cn/api_docs/core/add_message

--- a/content/cn/memos_cloud/introduction/algorithm.md
+++ b/content/cn/memos_cloud/introduction/algorithm.md
@@ -79,7 +79,7 @@ MemOS 的设计核心，是把「记忆」作为一个独立系统层，和计�
 
 ## 3. MemOS为什么高效？
 
-:::note{icon="ri:message-2-line"}
+:::note{icon="i-ri-message-2-line"}
 从Next-Token Prediction到Next-Scene Prediction
 :::
 

--- a/content/cn/memos_cloud/introduction/mem_production.md
+++ b/content/cn/memos_cloud/introduction/mem_production.md
@@ -71,7 +71,7 @@ Assistant: 好的，有其他问题再问我。
 ::card-group
   :::card
   ---
-  icon: ri:inbox-archive-line
+  icon: i-ri-inbox-archive-line
   title: 原始输入内容
   to: /cn/memos_cloud/introduction/raw_inputs
   ---
@@ -80,7 +80,7 @@ Assistant: 好的，有其他问题再问我。
 
   :::card
   ---
-  icon: ri:price-tag-3-line
+  icon: i-ri-price-tag-3-line
   title: 记忆类型
   to: /cn/memos_cloud/introduction/memory_types
   ---
@@ -89,7 +89,7 @@ Assistant: 好的，有其他问题再问我。
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /cn/memos_cloud/mem_operations/add_message
   ---

--- a/content/cn/memos_cloud/introduction/mem_recall.md
+++ b/content/cn/memos_cloud/introduction/mem_recall.md
@@ -52,7 +52,7 @@ desc: 记忆召回负责在用户发起请求时，从已有记忆中找出与�
 ::card-group
   :::card
   ---
-  icon: ri:filter-3-line
+  icon: i-ri-filter-3-line
   title: 记忆过滤
 
   to: /cn/memos_cloud/features/filters
@@ -62,7 +62,7 @@ desc: 记忆召回负责在用户发起请求时，从已有记忆中找出与�
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /cn/memos_cloud/mem_operations/search_memory
   ---

--- a/content/cn/memos_cloud/introduction/mem_schedule.md
+++ b/content/cn/memos_cloud/introduction/mem_schedule.md
@@ -39,7 +39,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: 用户输入
   ---
   “帮我查一下滨江那边的二手房均价。”<br>
@@ -49,7 +49,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: 调度结果
   ---
   生成小区、看房安排、房贷利率的记忆。<br>
@@ -67,7 +67,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: 用户输入
   ---
   “周末要去看瓷砖。”<br>
@@ -77,7 +77,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: 调度结果
   ---
   继续生成装修相关记忆。<br>
@@ -100,7 +100,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
   ---
   class: border-amber-200 bg-amber-50/70 dark:border-amber-800/50 dark:bg-amber-950/20
   color: warning
-  icon: ri:error-warning-line
+  icon: i-ri-error-warning-line
   title: 没有调度：全量临时检索
   ---
   需要从全量记忆里临时检索。<br>
@@ -112,7 +112,7 @@ desc: 记忆调度负责在对话和任务进行时，判断哪些记忆应该�
   ---
   class: border-emerald-200 bg-emerald-50/70 dark:border-emerald-800/50 dark:bg-emerald-950/20
   color: success
-  icon: ri:checkbox-circle-line
+  icon: i-ri-checkbox-circle-line
   title: 有调度：优先准备当前主题
   ---
   优先准备看瓷砖、确认水电改造、家具送货等装修记忆。<br>

--- a/content/cn/memos_cloud/introduction/memory_types.md
+++ b/content/cn/memos_cloud/introduction/memory_types.md
@@ -102,7 +102,7 @@ Skills 记录“任务怎么做”。MemOS 从历史消息中自动提炼技能�
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /cn/memos_cloud/mem_operations/add_message
   ---
@@ -111,7 +111,7 @@ Skills 记录“任务怎么做”。MemOS 从历史消息中自动提炼技能�
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /cn/memos_cloud/mem_operations/search_memory
   ---

--- a/content/cn/memos_cloud/introduction/raw_inputs.md
+++ b/content/cn/memos_cloud/introduction/raw_inputs.md
@@ -162,7 +162,7 @@ Agent 的工具调用决策和返回结果。MemOS 会生成工具记忆，帮�
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /cn/memos_cloud/mem_operations/add_message
   ---
@@ -171,7 +171,7 @@ Agent 的工具调用决策和返回结果。MemOS 会生成工具记忆，帮�
 
   :::card
   ---
-  icon: ri:chat-history-line
+  icon: i-ri-chat-history-line
   title: Chat
   to: /cn/memos_cloud/mem_operations/chat
   ---
@@ -180,7 +180,7 @@ Agent 的工具调用决策和返回结果。MemOS 会生成工具记忆，帮�
 
   :::card
   ---
-  icon: ri:book-read-line
+  icon: i-ri-book-read-line
   title: 知识库
   to: /cn/memos_cloud/features/knowledge_base
   ---
@@ -189,7 +189,7 @@ Agent 的工具调用决策和返回结果。MemOS 会生成工具记忆，帮�
 
   :::card
   ---
-  icon: ri:feedback-line
+  icon: i-ri-feedback-line
   title: Add Feedback
   to: /cn/memos_cloud/mem_operations/add_feedback
   ---

--- a/content/cn/memos_cloud/introduction/time_awareness.md
+++ b/content/cn/memos_cloud/introduction/time_awareness.md
@@ -122,7 +122,7 @@ MemOS 对记忆做不同的处理：
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /cn/memos_cloud/mem_operations/add_message
   ---
@@ -131,7 +131,7 @@ MemOS 对记忆做不同的处理：
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /cn/memos_cloud/mem_operations/search_memory
   ---

--- a/content/cn/memos_cloud/mem_operations/add_message.md
+++ b/content/cn/memos_cloud/mem_operations/add_message.md
@@ -263,7 +263,7 @@ data = {
 ::card-group
   :::card
   ---
-  icon: ri:image-line
+  icon: i-ri-image-line
   title: 多模态消息
   to: /cn/memos_cloud/features/multimodal
   ---
@@ -272,7 +272,7 @@ data = {
 
   :::card
   ---
-  icon: ri:tools-line
+  icon: i-ri-tools-line
   title: 工具记忆
   to: /cn/memos_cloud/features/tool_calling
   ---
@@ -281,7 +281,7 @@ data = {
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: 异步模式
   to: /cn/memos_cloud/features/async_mode
   ---
@@ -290,7 +290,7 @@ data = {
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: 知识库记忆
   to: /cn/memos_cloud/features/knowledge_base
   ---

--- a/content/cn/memos_cloud/mem_operations/chat.md
+++ b/content/cn/memos_cloud/mem_operations/chat.md
@@ -18,7 +18,7 @@ Chat 接口适合用于快速搭建带长期记忆能力的 AI 对话应用。�
 ::card-group
   :::card
   ---
-  icon: ri:chat-4-line
+  icon: i-ri-chat-4-line
   title: 使用 Chat
   ---
   适合通用 AI 对话、业务 PoC 和快速验证
@@ -26,7 +26,7 @@ Chat 接口适合用于快速搭建带长期记忆能力的 AI 对话应用。�
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: 使用记忆操作接口
   ---
   适合复杂 Agent 和业务系统深度集成

--- a/content/cn/memos_cloud/mem_operations/search_memory.md
+++ b/content/cn/memos_cloud/mem_operations/search_memory.md
@@ -264,7 +264,7 @@ data = {
 ::card-group
   :::card
   ---
-  icon: ri:tools-line
+  icon: i-ri-tools-line
   title: 召回工具记忆
 
   to: /cn/memos_cloud/features/tool_calling
@@ -274,7 +274,7 @@ data = {
 
   :::card
   ---
-  icon: ri:book-read-line
+  icon: i-ri-book-read-line
   title: 召回技能
 
   to: /cn/memos_cloud/features/skill
@@ -284,7 +284,7 @@ data = {
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: 检索知识库
 
   to: /cn/memos_cloud/features/knowledge_base

--- a/content/en/api_docs/api.json
+++ b/content/en/api_docs/api.json
@@ -2386,7 +2386,7 @@
                 "content": {
                   "type": "string",
                   "title": "Content",
-                  "description": "File content. Supports URL or Base64 encoding. For supported formats, size limits, and quantity limits for ordinary documents and Skill files, see <a href=\"/memos_cloud/features/advanced/knowledge_base\" class=\"text-primary border-b border-transparent hover:border-primary font-medium focus-visible:outline-primary [&amp;&gt;code]:border-dashed hover:[&amp;&gt;code]:border-primary hover:[&amp;&gt;code]:text-primary transition-colors [&amp;&gt;code]:transition-colors\">Knowledge Base requirements</a>."
+                  "description": "File content. Supports URL or Base64 encoding. For supported formats, size limits, and quantity limits for ordinary documents and Skill files, see <a href=\"/memos_cloud/features/knowledge_base\" class=\"text-primary border-b border-transparent hover:border-primary font-medium focus-visible:outline-primary [&amp;&gt;code]:border-dashed hover:[&amp;&gt;code]:border-primary hover:[&amp;&gt;code]:text-primary transition-colors [&amp;&gt;code]:transition-colors\">Knowledge Base requirements</a>."
                 }
               }
             }

--- a/content/en/api_docs/start/configuration.md
+++ b/content/en/api_docs/start/configuration.md
@@ -45,7 +45,7 @@ Deleting a project will clear all memories, messages, and related data under tha
     
 
 ::note
-To understand the principles and usage of knowledge bases, go to the [**Knowledge Base Introduction Page**](/memos_cloud/features/advanced/knowledge_base), and follow the explanation to create knowledge base document memories that can be recalled together with user memories step by step.
+To understand the principles and usage of knowledge bases, go to the [**Knowledge Base Introduction Page**](/memos_cloud/features/knowledge_base), and follow the explanation to create knowledge base document memories that can be recalled together with user memories step by step.
 ::
 
 ![image.png](https://cdn.memtensor.com.cn/img/1766631184791_98zzxh_compressed.png)

--- a/content/en/memos_cloud/features/knowledge_base.md
+++ b/content/en/memos_cloud/features/knowledge_base.md
@@ -91,7 +91,7 @@ DAY 20 Employee asks: The intranet proxy won't open. Which version should I rein
 # ✅ Knowledge Base Assistant: You are using a MacBook Pro with an Intel chip. It is recommended to reinstall the Intel version of the intranet proxy client. Here are the download link and installation steps for the Intel version: ...
 ```
 
-::note{icon="ri:triangular-flag-fill"}
+::note{icon="i-ri-triangular-flag-fill"}
 **&nbsp;Advantage Summary**<br>
 RAG is good at retrieving information semantically similar to the query from the knowledge base, but it is **stateless**: every query is independent, lacking understanding of the specific user and context.<br>
 

--- a/content/en/memos_cloud/getting_started/agent_usage.md
+++ b/content/en/memos_cloud/getting_started/agent_usage.md
@@ -142,7 +142,7 @@ Claude Desktop, Cline, Chatbox, and other clients are configured similarly, thou
 ::card-group
   :::card
   ---
-  icon: ri:puzzle-line
+  icon: i-ri-puzzle-line
   title: OpenClaw Cloud Plugin
   to: /openclaw/guide
   ---
@@ -151,7 +151,7 @@ Claude Desktop, Cline, Chatbox, and other clients are configured similarly, thou
 
   :::card
   ---
-  icon: ri:terminal-box-line
+  icon: i-ri-terminal-box-line
   title: MCP Guide
   to: /mcp_agent/mcp/guide
   ---
@@ -160,7 +160,7 @@ Claude Desktop, Cline, Chatbox, and other clients are configured similarly, thou
 
   :::card
   ---
-  icon: ri:file-code-line
+  icon: i-ri-file-code-line
   title: API / SDK
   to: /memos_cloud/getting_started/quick_start
   ---

--- a/content/en/memos_cloud/getting_started/overview.md
+++ b/content/en/memos_cloud/getting_started/overview.md
@@ -39,7 +39,7 @@ When retrieving memories, MemOS filters and recalls the most relevant memories f
 ::card-group
   :::card
   ---
-  icon: ri:rocket-line
+  icon: i-ri-rocket-line
   title: Quick Start
 
   to: /memos_cloud/getting_started/quick_start
@@ -49,7 +49,7 @@ When retrieving memories, MemOS filters and recalls the most relevant memories f
 
   :::card
   ---
-  icon: ri:brain-line
+  icon: i-ri-brain-line
   title: How MemOS Works
 
   to: /memos_cloud/introduction/mem_production
@@ -59,7 +59,7 @@ When retrieving memories, MemOS filters and recalls the most relevant memories f
 
   :::card
   ---
-  icon: ri:dashboard-line
+  icon: i-ri-dashboard-line
   title: Cloud Service & Open Source
 
   to: /memos_cloud/getting_started/cloud_and_opensource
@@ -69,7 +69,7 @@ When retrieving memories, MemOS filters and recalls the most relevant memories f
 
   :::card
   ---
-  icon: ri:robot-line
+  icon: i-ri-robot-line
   title: Use in Agents
 
   to: /memos_cloud/getting_started/agent_usage

--- a/content/en/memos_cloud/getting_started/quick_start.md
+++ b/content/en/memos_cloud/getting_started/quick_start.md
@@ -233,7 +233,7 @@ I want to travel during the National Day holiday. Please recommend a city I have
 ::card-group
   :::card
   ---
-  icon: ri:checkbox-circle-line
+  icon: i-ri-checkbox-circle-line
   title: Core Operations
   to: /memos_cloud/mem_operations/add_message
   ---
@@ -242,7 +242,7 @@ I want to travel during the National Day holiday. Please recommend a city I have
 
   :::card
   ---
-  icon: ri:robot-line
+  icon: i-ri-robot-line
   title: Use in Agents
 
   to: /memos_cloud/getting_started/agent_usage
@@ -252,7 +252,7 @@ I want to travel during the National Day holiday. Please recommend a city I have
 
   :::card
   ---
-  icon: ri:file-code-line
+  icon: i-ri-file-code-line
   title: API Reference
 
   to: /api_docs/core/add_message

--- a/content/en/memos_cloud/introduction/algorithm.md
+++ b/content/en/memos_cloud/introduction/algorithm.md
@@ -80,7 +80,7 @@ Its overall architecture can be summarized as a **three-layer structure**: <span
 
 ## 3. Why is MemOS Efficient?
 
-:::note{icon="ri:message-2-line"}
+:::note{icon="i-ri-message-2-line"}
 From Next-Token Prediction to Next-Scene Prediction
 :::
 

--- a/content/en/memos_cloud/introduction/mem_production.md
+++ b/content/en/memos_cloud/introduction/mem_production.md
@@ -59,7 +59,7 @@ Possible generated memories:
 ::card-group
   :::card
   ---
-  icon: ri:inbox-archive-line
+  icon: i-ri-inbox-archive-line
   title: Raw Input Content
   to: /memos_cloud/introduction/raw_inputs
   ---
@@ -68,7 +68,7 @@ Possible generated memories:
 
   :::card
   ---
-  icon: ri:price-tag-3-line
+  icon: i-ri-price-tag-3-line
   title: Memory Categories
   to: /memos_cloud/introduction/memory_types
   ---
@@ -77,7 +77,7 @@ Possible generated memories:
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /memos_cloud/mem_operations/add_message
   ---

--- a/content/en/memos_cloud/introduction/mem_recall.md
+++ b/content/en/memos_cloud/introduction/mem_recall.md
@@ -48,7 +48,7 @@ Together, these stages determine whether recalled memories are actually useful. 
 ::card-group
   :::card
   ---
-  icon: ri:filter-3-line
+  icon: i-ri-filter-3-line
   title: Memory Filters
   to: /memos_cloud/features/filters
   ---
@@ -57,7 +57,7 @@ Together, these stages determine whether recalled memories are actually useful. 
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /memos_cloud/mem_operations/search_memory
   ---

--- a/content/en/memos_cloud/introduction/mem_schedule.md
+++ b/content/en/memos_cloud/introduction/mem_schedule.md
@@ -39,7 +39,7 @@ Scheduling affects later recall and context injection. Relevant, active, and tru
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: User input
   ---
   "Help me check the average second-hand home price around Binjiang."<br>
@@ -49,7 +49,7 @@ Scheduling affects later recall and context injection. Relevant, active, and tru
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: Scheduling result
   ---
   Generate memories about communities, house-viewing schedules, and mortgage rates.<br>
@@ -67,7 +67,7 @@ Scheduling affects later recall and context injection. Relevant, active, and tru
 
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: User input
   ---
   "I'm going to look at tiles this weekend."<br>
@@ -77,7 +77,7 @@ Scheduling affects later recall and context injection. Relevant, active, and tru
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: Scheduling result
   ---
   Continue generating renovation-related memories.<br>
@@ -98,7 +98,7 @@ The user casually says: "I feel like a lot of things are piling up. Please sort 
   ---
   class: border-amber-200 bg-amber-50/70 dark:border-amber-800/50 dark:bg-amber-950/20
   color: warning
-  icon: ri:error-warning-line
+  icon: i-ri-error-warning-line
   title: Without scheduling: temporary full retrieval
   ---
   Needs to retrieve from all memories on the spot.<br>
@@ -110,7 +110,7 @@ The user casually says: "I feel like a lot of things are piling up. Please sort 
   ---
   class: border-emerald-200 bg-emerald-50/70 dark:border-emerald-800/50 dark:bg-emerald-950/20
   color: success
-  icon: ri:checkbox-circle-line
+  icon: i-ri-checkbox-circle-line
   title: With scheduling: prepare the current topic first
   ---
   Prioritize renovation memories such as looking at tiles, confirming plumbing and electrical work, and furniture delivery.<br>

--- a/content/en/memos_cloud/introduction/memory_types.md
+++ b/content/en/memos_cloud/introduction/memory_types.md
@@ -84,7 +84,7 @@ For the full field list, request format, and response format, see the [Search Me
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /memos_cloud/mem_operations/add_message
   ---
@@ -93,7 +93,7 @@ For the full field list, request format, and response format, see the [Search Me
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /memos_cloud/mem_operations/search_memory
   ---

--- a/content/en/memos_cloud/introduction/raw_inputs.md
+++ b/content/en/memos_cloud/introduction/raw_inputs.md
@@ -162,7 +162,7 @@ Project-level knowledge documents or Agent skill packages. These are managed sep
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /memos_cloud/mem_operations/add_message
   ---
@@ -171,7 +171,7 @@ Project-level knowledge documents or Agent skill packages. These are managed sep
 
   :::card
   ---
-  icon: ri:chat-history-line
+  icon: i-ri-chat-history-line
   title: Chat
   to: /memos_cloud/mem_operations/chat
   ---
@@ -180,7 +180,7 @@ Project-level knowledge documents or Agent skill packages. These are managed sep
 
   :::card
   ---
-  icon: ri:book-read-line
+  icon: i-ri-book-read-line
   title: Knowledge Base
   to: /memos_cloud/features/knowledge_base
   ---
@@ -189,7 +189,7 @@ Project-level knowledge documents or Agent skill packages. These are managed sep
 
   :::card
   ---
-  icon: ri:feedback-line
+  icon: i-ri-feedback-line
   title: Add Feedback
   to: /memos_cloud/mem_operations/add_feedback
   ---

--- a/content/en/memos_cloud/introduction/time_awareness.md
+++ b/content/en/memos_cloud/introduction/time_awareness.md
@@ -104,7 +104,7 @@ Try writing a set of events with time information:
 ::card-group
   :::card
   ---
-  icon: ri:message-3-line
+  icon: i-ri-message-3-line
   title: Add Message
   to: /memos_cloud/mem_operations/add_message
   ---
@@ -113,7 +113,7 @@ Try writing a set of events with time information:
 
   :::card
   ---
-  icon: ri:search-2-line
+  icon: i-ri-search-2-line
   title: Search Memory
   to: /memos_cloud/mem_operations/search_memory
   ---

--- a/content/en/memos_cloud/mem_operations/add_message.md
+++ b/content/en/memos_cloud/mem_operations/add_message.md
@@ -238,7 +238,7 @@ If you need more complex write methods, continue with these extended capabilitie
 ::card-group
   :::card
   ---
-  icon: ri:image-line
+  icon: i-ri-image-line
   title: Multimodal Messages
   to: /memos_cloud/features/multimodal
   ---
@@ -247,7 +247,7 @@ If you need more complex write methods, continue with these extended capabilitie
 
   :::card
   ---
-  icon: ri:tools-line
+  icon: i-ri-tools-line
   title: Tool Memory
   to: /memos_cloud/features/tool_calling
   ---
@@ -256,7 +256,7 @@ If you need more complex write methods, continue with these extended capabilitie
 
   :::card
   ---
-  icon: ri:timer-flash-line
+  icon: i-ri-timer-flash-line
   title: Async Mode
   to: /memos_cloud/features/async_mode
   ---
@@ -265,7 +265,7 @@ If you need more complex write methods, continue with these extended capabilitie
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: Knowledge Base Memories
   to: /memos_cloud/features/knowledge_base
   ---

--- a/content/en/memos_cloud/mem_operations/chat.md
+++ b/content/en/memos_cloud/mem_operations/chat.md
@@ -16,7 +16,7 @@ The Chat API is suitable for quickly building AI conversation applications with 
 ::card-group
   :::card
   ---
-  icon: ri:chat-4-line
+  icon: i-ri-chat-4-line
   title: Use Chat
   ---
   Best for general AI conversations, business PoCs, and quick validation
@@ -24,7 +24,7 @@ The Chat API is suitable for quickly building AI conversation applications with 
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: Use Memory Operation APIs
   ---
   Best for complex Agents and deeper business-system integration

--- a/content/en/memos_cloud/mem_operations/search_memory.md
+++ b/content/en/memos_cloud/mem_operations/search_memory.md
@@ -246,7 +246,7 @@ data = {
 ::card-group
   :::card
   ---
-  icon: ri:tools-line
+  icon: i-ri-tools-line
   title: Recall Tool Memories
 
   to: /memos_cloud/features/tool_calling
@@ -256,7 +256,7 @@ data = {
 
   :::card
   ---
-  icon: ri:book-read-line
+  icon: i-ri-book-read-line
   title: Recall Skills
 
   to: /memos_cloud/features/skill
@@ -266,7 +266,7 @@ data = {
 
   :::card
   ---
-  icon: ri:database-2-line
+  icon: i-ri-database-2-line
   title: Search Knowledge Bases
 
   to: /memos_cloud/features/knowledge_base

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@iconify-json/lucide": "^1.2.47",
+    "@iconify-json/ri": "^1.2.10",
     "@iconify-json/simple-icons": "^1.2.38",
     "@iconify-json/vscode-icons": "^1.2.22",
     "@nuxt/content": "^3.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@iconify-json/lucide':
         specifier: ^1.2.47
         version: 1.2.87
+      '@iconify-json/ri':
+        specifier: ^1.2.10
+        version: 1.2.10
       '@iconify-json/simple-icons':
         specifier: ^1.2.38
         version: 1.2.68
@@ -718,6 +721,9 @@ packages:
 
   '@iconify-json/lucide@1.2.87':
     resolution: {integrity: sha512-wxYIAp0f8Uw0rJa6BMWMaRbiHk3yV4XczA38GKXFlqyZtTdmHM1QOF4NZw5xpMlRDzbh2MnB7wjteLeFnn/ciQ==}
+
+  '@iconify-json/ri@1.2.10':
+    resolution: {integrity: sha512-WWMhoncVVM+Xmu9T5fgu2lhYRrKTEWhKk3Com0KiM111EeEsRLiASjpsFKnC/SrB6covhUp95r2mH8tGxhgd5Q==}
 
   '@iconify-json/simple-icons@1.2.68':
     resolution: {integrity: sha512-bQPl1zuZlX6AnofreA1v7J+hoPncrFMppqGboe/SH54jZO37meiBUGBqNOxEpc0HKfZGxJaVVJwZd4gdMYu3hw==}
@@ -6832,6 +6838,10 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify-json/lucide@1.2.87':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/ri@1.2.10':
     dependencies:
       '@iconify/types': 2.0.0
 


### PR DESCRIPTION
## Summary
- add the missing Remix Icon collection used by the docs navigation and cards
- normalize newly added MemOS Cloud card icons to Nuxt UI's i-ri-* icon format
- update stale knowledge base links that pointed to the old advanced feature path

## Verification
- pnpm install --frozen-lockfile
- npm run build