### PR TITLE
docs(snippets): fix syntax error in client.delete_knowledgebase-file() method name

### DIFF
--- a/content/cn/api_docs/snippets/delete_knowledgebase-file.md
+++ b/content/cn/api_docs/snippets/delete_knowledgebase-file.md
@@ -30,7 +30,7 @@ client = MemOSClient(api_key="YOUR_API_KEY")
 
 file_ids = ["3711d404c51592c4eebae46900236f50"] # 替换为知识库文档 ID
 
-res = client.delete_knowledgebase-file(file_ids=file_ids)
+res = client.delete_knowledgebase_file(file_ids=file_ids)
 
 print(f"result: {res}")
 ```

--- a/content/en/api_docs/snippets/delete_knowledgebase-file.md
+++ b/content/en/api_docs/snippets/delete_knowledgebase-file.md
@@ -30,7 +30,7 @@ client = MemOSClient(api_key="YOUR_API_KEY")
 
 file_ids = ["3711d404c51592c4eebae46900236f50"] # Replace with Knowledge Base File ID
 
-res = client.delete_knowledgebase-file(file_ids=file_ids)
+res = client.delete_knowledgebase_file(file_ids=file_ids)
 
 print(f"result: {res}")
 ```


### PR DESCRIPTION
## 问题
`content/cn/api_docs/snippets/delete_knowledgebase-file.md` 中的命令执行失败：
- `client.delete_knowledgebase-file(file_ids=file_ids)` → SyntaxError: invalid syntax

## Root Cause
`syntax_error_in_doc` - 方法名 `delete_knowledgebase-file` 使用了减号，Python 语法不允许。

## 修复内容
- 将 `client.delete_knowledgebase-file(file_ids=file_ids)` 改为 `client.delete_knowledgebase_file(file_ids=file_ids)`，以符合 Python 的命名规则。

---
> 这是 Doc Agent 自动起草的 **draft PR**，模式：`source_patch`。请 review 每个文件 diff，确认无误后再合并。
> 如有 patch 应用失败的文件，会在底部以「未应用 patches」附建议供人工处理。

---
## Doc Agent patches
### 已自动应用 (1)
- `content/cn/api_docs/snippets/delete_knowledgebase-file.md` (line_replace)