### PR TITLE
docs: add OpenClaw knowledge base examples

### DIFF
--- a/content/cn/openclaw/examples/knowledge_base.md
+++ b/content/cn/openclaw/examples/knowledge_base.md
@@ -1,0 +1,151 @@
+---
+title: 知识库使用
+desc: 在 MemOS Cloud 控制台创建知识库，并在 OpenClaw 云插件中配置知识库 ID 进行检索。
+---
+
+## 云插件
+
+MemOS OpenClaw 云插件可以在每轮任务开始前，基于当前问题同时召回个人记忆和指定知识库内容。适合把产品文档、公司制度、项目资料、代码规范等长期资料接入 OpenClaw，让 Agent 在执行任务时自动参考这些资料。
+
+### 1. 创建知识库并获取 ID
+
+知识库需要先在 [MemOS Cloud Dashboard](https://memos-dashboard.openmem.net) 中创建。
+
+操作步骤：
+
+1. 登录 [MemOS Cloud Dashboard](https://memos-dashboard.openmem.net)。
+2. 进入知识库管理页面，创建新的知识库。
+3. 上传需要被 Agent 检索的文档或 Skill 文件。
+4. 等待文件处理完成。
+5. 在知识库详情页复制知识库 ID，例如 `kb-company-handbook`。
+
+::warning
+请使用控制台中复制到的真实知识库 ID 替换下面示例里的 `kb-company-handbook`。知识库名称只是展示名，插件配置需要填写知识库 ID。
+::
+
+### 2. 配置全局知识库
+
+知识库相关配置分为两个方向：
+
+- `knowledgebaseIds` / `MEMOS_KNOWLEDGEBASE_IDS`：负责查询知识库，插件在 `/search/memory` 阶段从这些知识库中召回内容。
+- `allowKnowledgebaseIds` / `MEMOS_ALLOW_KNOWLEDGEBASE_IDS`：负责写入知识库，插件在 `/add/message` 阶段允许把新增记忆写入这些知识库。
+
+如果希望所有 OpenClaw 会话都可以检索同一个知识库，可以在 `~/.openclaw/openclaw.json` 中配置 `knowledgebaseIds`：
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "apiKey": "YOUR_MEMOS_API_KEY",
+          "knowledgebaseIds": ["kb-company-handbook"],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45
+        }
+      }
+    }
+  }
+}
+```
+
+配置完成后重启 OpenClaw gateway：
+
+```bash
+openclaw gateway restart
+```
+
+### 3. 使用环境变量配置
+
+也可以在 `~/.openclaw/.env` 中配置知识库 ID：
+
+```bash
+MEMOS_API_KEY=YOUR_MEMOS_API_KEY
+MEMOS_KNOWLEDGEBASE_IDS="kb-company-handbook,kb-product-docs"
+```
+
+`MEMOS_KNOWLEDGEBASE_IDS` 对应检索阶段的知识库范围，也就是插件调用 `/search/memory` 时会读取这些知识库。
+
+如果需要把对话新增记忆写入知识库，需要额外配置写入参数：
+
+```bash
+MEMOS_ALLOW_KNOWLEDGEBASE_IDS="kb-company-handbook"
+```
+
+::warning
+知识库写入会让 Agent 产生的信息进入对应知识库，但知识库内容本身不会按 `agent_id` 做隔离过滤。也就是说，一旦多个 Agent 都配置读取同一个知识库，写入该知识库的信息就可能被这些 Agent 共同召回，从而削弱多 Agent 记忆隔离效果。
+
+如果你希望严格保持 Agent 隔离，建议不要把对话记忆写入共享知识库；只有在明确希望沉淀为团队共享知识时，再配置 `allowKnowledgebaseIds` 或 `MEMOS_ALLOW_KNOWLEDGEBASE_IDS`。
+::
+
+### 4. 多 Agent 分别绑定知识库
+
+当不同 Agent 负责不同任务时，建议开启多 Agent 模式，并通过 `agentOverrides` 为每个 Agent 配置自己的知识库：
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "multiAgentMode": true,
+          "allowedAgents": ["research-agent", "coding-agent"],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45,
+          "agentOverrides": {
+            "research-agent": {
+              "knowledgebaseIds": ["kb-research-papers"],
+              "memoryLimitNumber": 12,
+              "queryPrefix": "research context: "
+            },
+            "coding-agent": {
+              "knowledgebaseIds": ["kb-codebase", "kb-api-docs"],
+              "memoryLimitNumber": 9,
+              "includeToolMemory": true,
+              "addEnabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+上面的配置表示：
+
+- `research-agent` 会优先检索论文 / 研究资料知识库。
+- `coding-agent` 会检索代码库和 API 文档知识库，并关闭对话写入，避免把临时调试过程沉淀到长期记忆中。
+- 未出现在 `agentOverrides` 中的 Agent 会继承全局配置。
+
+如果在多 Agent 场景中开启知识库写入，请确保写入目标不是多个 Agent 共同读取的共享知识库，否则不同 Agent 的信息可能通过知识库互相可见。
+
+### 5. 验证知识库召回
+
+配置完成后，可以向 OpenClaw 提问一个只有知识库文档中才有答案的问题：
+
+```text
+你：根据公司报销制度，设计软件采购超过多少金额需要特殊审批？
+OpenClaw：根据知识库中的采购规则，设计软件采购超过 1000 元需要特殊审批……
+```
+
+如果回答没有引用知识库内容，可以按下面顺序排查：
+
+- 确认知识库文件在 Dashboard 中已经处理完成。
+- 确认 `knowledgebaseIds` 或 `MEMOS_KNOWLEDGEBASE_IDS` 使用的是知识库 ID，不是知识库名称。
+- 确认 OpenClaw gateway 已重启并加载了最新配置。
+- 如果使用多 Agent，确认当前 Agent 在 `allowedAgents` 中，并且对应 `agentOverrides` 配置正确。
+
+### 配置参考
+
+知识库相关配置请参考 [MemOS-Cloud-OpenClaw-Plugin 官方仓库](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin)：
+
+| 配置项 | 用途 |
+| --- | --- |
+| `knowledgebaseIds` | 查询知识库。插件配置中的知识库检索范围，对应 `/search/memory`。 |
+| `MEMOS_KNOWLEDGEBASE_IDS` | 查询知识库。环境变量形式的知识库检索范围，多个 ID 用英文逗号分隔。 |
+| `allowKnowledgebaseIds` | 写入知识库。插件配置中的新增记忆允许写入知识库范围，对应 `/add/message`。 |
+| `MEMOS_ALLOW_KNOWLEDGEBASE_IDS` | 写入知识库。环境变量形式的新增记忆允许写入知识库范围。 |
+| `agentOverrides.<agentId>.knowledgebaseIds` | 多 Agent 场景下，为某个 Agent 单独指定知识库。 |

--- a/content/cn/openclaw/examples/multi_agent.md
+++ b/content/cn/openclaw/examples/multi_agent.md
@@ -49,10 +49,81 @@ MEMOS_MULTI_AGENT_MODE=true
 }
 ```
 
+#### 4. 按 Agent 单独配置参数（可选）
+
+除了隔离记忆空间，还可以通过 `agentOverrides` 给不同 Agent 单独覆盖知识库、召回条数、相关性阈值、是否写入记忆等参数。未配置的字段会继承全局配置。
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "multiAgentMode": true,
+          "allowedAgents": ["research-agent", "coding-agent"],
+          "knowledgebaseIds": [],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45,
+          "agentOverrides": {
+            "research-agent": {
+              "knowledgebaseIds": ["kb-research-papers", "kb-academic"],
+              "memoryLimitNumber": 12,
+              "relativity": 0.3,
+              "includeToolMemory": true,
+              "captureStrategy": "full_session",
+              "queryPrefix": "research context: "
+            },
+            "coding-agent": {
+              "knowledgebaseIds": ["kb-codebase", "kb-api-docs"],
+              "memoryLimitNumber": 9,
+              "relativity": 0.5,
+              "addEnabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+上面的配置表示：
+
+- `research-agent` 使用论文 / 学术知识库，召回更多记忆，并开启工具记忆。
+- `coding-agent` 只读取代码库和 API 文档知识库，并关闭记忆写入。
+- 其他 Agent 如果被允许使用记忆，则沿用全局的 `knowledgebaseIds`、`memoryLimitNumber` 和 `relativity`。
+
+`.env` 中也可以使用 `MEMOS_AGENT_OVERRIDES` 配置 JSON 字符串，但优先级低于 `openclaw.json` 中的 `agentOverrides`：
+
+```bash
+MEMOS_AGENT_OVERRIDES='{"research-agent":{"memoryLimitNumber":12,"relativity":0.3},"coding-agent":{"memoryLimitNumber":9,"addEnabled":false}}'
+```
+
+常用可覆盖字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `knowledgebaseIds` | 当前 Agent 检索的知识库 ID 列表。 |
+| `memoryLimitNumber` | 当前 Agent 最多召回的记忆条数。 |
+| `preferenceLimitNumber` | 当前 Agent 最多召回的偏好记忆条数。 |
+| `includePreference` | 是否召回偏好记忆。 |
+| `includeToolMemory` | 是否召回工具记忆。 |
+| `toolMemoryLimitNumber` | 工具记忆最多召回条数。 |
+| `relativity` | 相关性阈值，取值范围通常为 `0-1`。 |
+| `recallEnabled` | 是否为当前 Agent 开启记忆召回。 |
+| `addEnabled` | 是否为当前 Agent 开启记忆写入。 |
+| `captureStrategy` | 写入策略，例如 `last_turn` 或 `full_session`。 |
+| `queryPrefix` | 当前 Agent 的检索 query 前缀。 |
+| `recallFilterEnabled` | 是否开启召回二次过滤。 |
+| `allowKnowledgebaseIds` | 当前 Agent 允许写入的知识库 ID 列表。 |
+| `tags` | 写入记忆时附加的标签。 |
+
 ### 原理介绍
 
 - **/search/memory**：检索记忆——只返回当前 Agent 的记忆
 - **/add/message**：添加记录——自动标记为当前 Agent 的数据
+- **配置合并**：插件先读取全局配置，再用 `agentOverrides.<agentId>` 覆盖当前 Agent 的局部配置
 - **向下兼容**：默认 Agent `"main"` 会被忽略，保证老用户的单 Agent 数据不受影响
 
 ### 适用场景

--- a/content/cn/settings.yml
+++ b/content/cn/settings.yml
@@ -107,6 +107,7 @@ nav:
       - "(ri:cloud-line) OpenClaw 云插件": openclaw/guide.md
       - "(ri:computer-line) 本地插件": openclaw/local_plugin.md
     - "(ri:flask-line) 使用示例": 
+      - "(ri:database-2-line) 知识库使用": openclaw/examples/knowledge_base.md
       - "(ri:team-line) 多智能体记忆隔离": openclaw/examples/multi_agent.md
       - "(ri:filter-3-line) 记忆召回的二次过滤": openclaw/examples/recall_filter.md
       - "(ri:terminal-box-line) 本地插件使用": openclaw/examples/hermes_usage.md

--- a/content/en/openclaw/examples/knowledge_base.md
+++ b/content/en/openclaw/examples/knowledge_base.md
@@ -1,0 +1,152 @@
+---
+title: Knowledge Base Usage
+desc: Create a knowledge base in MemOS Cloud Dashboard and configure its knowledge base ID in the OpenClaw cloud plugin.
+---
+
+## Cloud Plugin
+
+The MemOS OpenClaw cloud plugin can recall both personal memories and selected knowledge base content before each task. This is useful for connecting product docs, company policies, project materials, coding standards, and other long-lived references to OpenClaw so the Agent can automatically use them during execution.
+
+### 1. Create a Knowledge Base and Get Its ID
+
+Create the knowledge base in [MemOS Cloud Dashboard](https://memos-dashboard.openmem.net) first.
+
+Steps:
+
+1. Log in to [MemOS Cloud Dashboard](https://memos-dashboard.openmem.net).
+2. Go to the knowledge base management page and create a new knowledge base.
+3. Upload the documents or Skill files that the Agent should retrieve from.
+4. Wait until file processing is complete.
+5. Copy the knowledge base ID from the knowledge base details page, for example `kb-company-handbook`.
+
+::warning
+Use the real knowledge base ID copied from the dashboard to replace `kb-company-handbook` in the examples below. The knowledge base name is only a display name; the plugin configuration requires the knowledge base ID.
+::
+
+### 2. Configure a Global Knowledge Base
+
+Knowledge base configuration has two directions:
+
+- `knowledgebaseIds` / `MEMOS_KNOWLEDGEBASE_IDS`: queries knowledge bases. During `/search/memory`, the plugin recalls content from these knowledge bases.
+- `allowKnowledgebaseIds` / `MEMOS_ALLOW_KNOWLEDGEBASE_IDS`: writes to knowledge bases. During `/add/message`, the plugin is allowed to write newly generated memories to these knowledge bases.
+
+If all OpenClaw sessions should retrieve from the same knowledge base, configure `knowledgebaseIds` in `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "apiKey": "YOUR_MEMOS_API_KEY",
+          "knowledgebaseIds": ["kb-company-handbook"],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the OpenClaw gateway after updating the config:
+
+```bash
+openclaw gateway restart
+```
+
+### 3. Configure with Environment Variables
+
+You can also configure knowledge base IDs in `~/.openclaw/.env`:
+
+```bash
+MEMOS_API_KEY=YOUR_MEMOS_API_KEY
+MEMOS_KNOWLEDGEBASE_IDS="kb-company-handbook,kb-product-docs"
+```
+
+`MEMOS_KNOWLEDGEBASE_IDS` defines the knowledge base scope for retrieval. The plugin reads from these knowledge bases when calling `/search/memory`.
+
+If you need to write newly generated conversation memories into a knowledge base, configure the write parameter separately:
+
+```bash
+MEMOS_ALLOW_KNOWLEDGEBASE_IDS="kb-company-handbook"
+```
+
+::warning
+Knowledge base writes can store Agent-generated information into the target knowledge base, but knowledge base content is not filtered by `agent_id`. In other words, if multiple Agents are configured to read the same knowledge base, anything written into that knowledge base may be recalled by all of them, weakening multi-agent memory isolation.
+
+If you need strict Agent isolation, do not write conversation memories into a shared knowledge base. Configure `allowKnowledgebaseIds` or `MEMOS_ALLOW_KNOWLEDGEBASE_IDS` only when you explicitly want the content to become shared team knowledge.
+::
+
+### 4. Bind Different Knowledge Bases to Different Agents
+
+When different Agents own different tasks, enable multi-agent mode and use `agentOverrides` to assign knowledge bases per Agent:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "multiAgentMode": true,
+          "allowedAgents": ["research-agent", "coding-agent"],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45,
+          "agentOverrides": {
+            "research-agent": {
+              "knowledgebaseIds": ["kb-research-papers"],
+              "memoryLimitNumber": 12,
+              "queryPrefix": "research context: "
+            },
+            "coding-agent": {
+              "knowledgebaseIds": ["kb-codebase", "kb-api-docs"],
+              "memoryLimitNumber": 9,
+              "includeToolMemory": true,
+              "addEnabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This configuration means:
+
+- `research-agent` retrieves from research paper / academic knowledge bases.
+- `coding-agent` retrieves from codebase and API documentation knowledge bases, and disables memory writes to avoid storing temporary debugging details as long-term memory.
+- Agents not listed in `agentOverrides` inherit the global configuration.
+
+If you enable knowledge base writes in a multi-agent setup, make sure the write target is not a shared knowledge base read by multiple Agents. Otherwise, information from different Agents may become visible to each other through the knowledge base.
+
+### 5. Verify Knowledge Base Recall
+
+After configuration, ask OpenClaw a question that can only be answered from the uploaded knowledge base documents:
+
+```text
+You: According to the company reimbursement policy, what purchase amount for design software requires special approval?
+OpenClaw: According to the procurement rules in the knowledge base, design software purchases above 1000 require special approval...
+```
+
+If the answer does not use knowledge base content, check the following:
+
+- Confirm that the knowledge base files have finished processing in the dashboard.
+- Confirm that `knowledgebaseIds` or `MEMOS_KNOWLEDGEBASE_IDS` uses the knowledge base ID, not the knowledge base name.
+- Confirm that the OpenClaw gateway has been restarted and loaded the latest config.
+- If using multi-agent mode, confirm that the current Agent is listed in `allowedAgents` and that the corresponding `agentOverrides` config is correct.
+
+### Config Reference
+
+For knowledge base configuration details, see the [official MemOS-Cloud-OpenClaw-Plugin repository](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin):
+
+| Config | Purpose |
+| --- | --- |
+| `knowledgebaseIds` | Query knowledge bases. Plugin config for the knowledge base retrieval scope, corresponding to `/search/memory`. |
+| `MEMOS_KNOWLEDGEBASE_IDS` | Query knowledge bases. Environment variable form of the knowledge base retrieval scope. Separate multiple IDs with commas. |
+| `allowKnowledgebaseIds` | Write to knowledge bases. Plugin config for knowledge bases that newly generated memories may be written to, corresponding to `/add/message`. |
+| `MEMOS_ALLOW_KNOWLEDGEBASE_IDS` | Write to knowledge bases. Environment variable form of knowledge bases that newly generated memories may be written to. |
+| `agentOverrides.<agentId>.knowledgebaseIds` | In multi-agent scenarios, assign knowledge bases to a specific Agent. |
+

--- a/content/en/openclaw/examples/multi_agent.md
+++ b/content/en/openclaw/examples/multi_agent.md
@@ -50,10 +50,81 @@ If you need to pin a specific Agent ID, set it in the config:
 }
 ```
 
+#### 4. Configure Parameters Per Agent (Optional)
+
+Beyond isolating memory spaces, you can use `agentOverrides` to override parameters for each Agent, such as knowledge bases, recall limits, relevance threshold, and whether memory writes are enabled. Fields that are not specified inherit from the global config.
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "memos-cloud-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "multiAgentMode": true,
+          "allowedAgents": ["research-agent", "coding-agent"],
+          "knowledgebaseIds": [],
+          "memoryLimitNumber": 6,
+          "relativity": 0.45,
+          "agentOverrides": {
+            "research-agent": {
+              "knowledgebaseIds": ["kb-research-papers", "kb-academic"],
+              "memoryLimitNumber": 12,
+              "relativity": 0.3,
+              "includeToolMemory": true,
+              "captureStrategy": "full_session",
+              "queryPrefix": "research context: "
+            },
+            "coding-agent": {
+              "knowledgebaseIds": ["kb-codebase", "kb-api-docs"],
+              "memoryLimitNumber": 9,
+              "relativity": 0.5,
+              "addEnabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This configuration means:
+
+- `research-agent` uses research / academic knowledge bases, recalls more memories, and includes tool memory.
+- `coding-agent` only reads from codebase and API documentation knowledge bases, and disables memory writes.
+- Other Agents, if allowed to use memory, inherit global `knowledgebaseIds`, `memoryLimitNumber`, and `relativity`.
+
+You can also configure a JSON string in `.env` with `MEMOS_AGENT_OVERRIDES`, but it has lower priority than `agentOverrides` in `openclaw.json`:
+
+```bash
+MEMOS_AGENT_OVERRIDES='{"research-agent":{"memoryLimitNumber":12,"relativity":0.3},"coding-agent":{"memoryLimitNumber":9,"addEnabled":false}}'
+```
+
+Common overridable fields:
+
+| Field | Description |
+| --- | --- |
+| `knowledgebaseIds` | Knowledge base IDs retrieved by the current Agent. |
+| `memoryLimitNumber` | Maximum number of memory items recalled by the current Agent. |
+| `preferenceLimitNumber` | Maximum number of preference memories recalled by the current Agent. |
+| `includePreference` | Whether to recall preference memories. |
+| `includeToolMemory` | Whether to recall tool memories. |
+| `toolMemoryLimitNumber` | Maximum number of tool memories to recall. |
+| `relativity` | Relevance threshold, usually between `0` and `1`. |
+| `recallEnabled` | Whether memory recall is enabled for the current Agent. |
+| `addEnabled` | Whether memory writes are enabled for the current Agent. |
+| `captureStrategy` | Capture strategy, such as `last_turn` or `full_session`. |
+| `queryPrefix` | Search query prefix for the current Agent. |
+| `recallFilterEnabled` | Whether secondary recall filtering is enabled. |
+| `allowKnowledgebaseIds` | Knowledge base IDs that the current Agent is allowed to write to. |
+| `tags` | Tags attached when writing memories. |
+
 ### Principles
 
 - **/search/memory**: Memory retrieval — returns only the current Agent's memories
 - **/add/message**: Record insertion — automatically tags data for the current Agent
+- **Config merging**: the plugin reads global config first, then applies `agentOverrides.<agentId>` for the current Agent
 - **Backward compatibility**: Default Agent `"main"` is ignored to keep existing single-Agent data unaffected
 
 ### Use Cases

--- a/content/en/settings.yml
+++ b/content/en/settings.yml
@@ -100,6 +100,7 @@ nav:
       - "(ri:cloud-line) OpenClaw Cloud Plugin": openclaw/guide.md
       - "(ri:computer-line) Local Plugin": openclaw/local_plugin.md
     - "(ri:flask-line) Usage Examples": 
+      - "(ri:database-2-line) Knowledge Base Usage": openclaw/examples/knowledge_base.md
       - "(ri:team-line) Multi-Agent Memory Isolation": openclaw/examples/multi_agent.md
       - "(ri:filter-3-line) Secondary Filtering for Memory Recall": openclaw/examples/recall_filter.md
       - "(ri:terminal-box-line) Local Plugin Usage": openclaw/examples/hermes_usage.md


### PR DESCRIPTION
## Summary

- Add CN/EN OpenClaw knowledge base usage examples
- Document how to create a knowledge base from MemOS Cloud Dashboard and configure knowledge base IDs
- Clarify the two knowledge base config directions:
  - `knowledgebaseIds` / `MEMOS_KNOWLEDGEBASE_IDS` for retrieval
  - `allowKnowledgebaseIds` / `MEMOS_ALLOW_KNOWLEDGEBASE_IDS` for writes
- Add warnings that writing Agent-generated memories into a shared knowledge base can weaken multi-agent isolation
- Expand CN/EN multi-agent examples with `agentOverrides` per-Agent configuration examples and overridable fields
- Add the new knowledge base examples to CN/EN side navigation

## Testing

- Verified CN/EN sidebar YAML parses successfully
- Checked Markdown warning directive pairs and key environment variable references
- `pnpm typecheck` was run, but it fails on existing TypeScript errors in `app/` and OpenAPI-related components unrelated to this docs change