### PR TITLE
docs: mark knowledge base output blocks as text

### DIFF
--- a/content/en/memos_cloud/features/knowledge_base.md
+++ b/content/en/memos_cloud/features/knowledge_base.md
@@ -212,7 +212,7 @@ res = requests.post(url=url, headers=headers, data=json.dumps(data))
 
 print(f"result: {res.json()}")
 ```
-```python [Output]
+```text [Output]
 "result": {
   "code": 0,
   "data": {
@@ -252,7 +252,7 @@ res = requests.post(url=url, headers=headers, data=json.dumps(data))
 
 print(f"result: {res.json()}")
 ```
-```python [Output]
+```text [Output]
 "result": {
   "code": 0,
   "data": [
@@ -352,7 +352,7 @@ json_res = res.json()
 print(json.dumps(json_res, indent=2, ensure_ascii=False))
 ```
 
-```python [Output]
+```text [Output]
 "memory_detail_list": [
   {
     "id": "2c760355-de4b-4a8f-b98d-b92851d23fa7",


### PR DESCRIPTION
Fixes Doc Agent review item #129959.\n\nThe knowledge base guide used `python [Output]` fences for literal output examples. Doc Agent correctly surfaced that those blocks are not valid Python, because they contain JSON-like output and inline explanatory comments.\n\nThis changes the three output fences in `content/en/memos_cloud/features/knowledge_base.md` to `text [Output]` so they remain rendered as examples without being treated as executable Python.