### PR TITLE
feat: add llms files and markdown export

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -131,6 +131,8 @@ const config: NuxtConfig = {
       routes: [
         '/',
         '/cn',
+        '/llms.txt',
+        '/llms-full.txt',
         ...cnRoutes,
         ...cnApiRoutes
       ],

--- a/scripts/export-markdown.mjs
+++ b/scripts/export-markdown.mjs
@@ -1,0 +1,55 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'fs'
+import { dirname, join, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const repoRoot = join(__dirname, '..')
+const publicDir = join(repoRoot, '.output', 'public')
+
+const locales = [
+  {
+    sourceDir: join(repoRoot, 'content', 'cn'),
+    outputDir: join(publicDir, 'cn')
+  },
+  {
+    sourceDir: join(repoRoot, 'content', 'en'),
+    outputDir: publicDir
+  }
+]
+
+function copyMarkdownFiles(sourceDir, outputDir, currentDir = sourceDir) {
+  let count = 0
+
+  for (const item of readdirSync(currentDir)) {
+    const sourcePath = join(currentDir, item)
+    const stats = statSync(sourcePath)
+
+    if (stats.isDirectory()) {
+      count += copyMarkdownFiles(sourceDir, outputDir, sourcePath)
+      continue
+    }
+
+    if (!stats.isFile() || !item.endsWith('.md')) continue
+
+    const outputPath = join(outputDir, relative(sourceDir, sourcePath))
+    mkdirSync(dirname(outputPath), { recursive: true })
+    copyFileSync(sourcePath, outputPath)
+    count += 1
+  }
+
+  return count
+}
+
+if (!existsSync(publicDir)) {
+  console.error('❌ Markdown export failed: .output/public does not exist. Run nuxt generate first.')
+  process.exit(1)
+}
+
+let total = 0
+for (const { sourceDir, outputDir } of locales) {
+  if (!existsSync(sourceDir)) continue
+  total += copyMarkdownFiles(sourceDir, outputDir)
+}
+
+console.log(`📄 Exported ${total} Markdown files to .output/public`)

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -46,6 +46,12 @@ try {
     stdio: 'inherit',
     env: { ...process.env }
   })
+
+  execSync('node scripts/export-markdown.mjs', {
+    stdio: 'inherit',
+    env: { ...process.env }
+  })
+
   console.log('✨ Build process completed!')
 } catch (error) {
   console.error('❌ Build failed:', error.message)

--- a/server/middleware/llm-markdown.ts
+++ b/server/middleware/llm-markdown.ts
@@ -1,0 +1,61 @@
+import { defineEventHandler, getRequestURL, getHeader } from 'h3'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function resolveMarkdownFile(slug: string): string | null {
+  const contentDir = path.resolve(process.cwd(), 'content')
+  const candidates = [
+    path.join(contentDir, `${slug}.md`),
+    path.join(contentDir, slug, 'index.md')
+  ]
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function isMarkdownPreferred(accept: string): boolean {
+  if (!accept) return false
+  const types = accept.split(',').map(t => t.split(';')[0].trim().toLowerCase())
+  const mdIndex = types.findIndex(t => t === 'text/markdown' || t === 'text/x-markdown')
+  const htmlIndex = types.findIndex(t => t === 'text/html' || t === '*/*')
+  if (mdIndex === -1) return false
+  if (htmlIndex === -1) return true
+  return mdIndex < htmlIndex
+}
+
+export default defineEventHandler((event) => {
+  const url = getRequestURL(event)
+  const pathname = url.pathname
+
+  // Skip non-doc routes
+  if (pathname.startsWith('/_') || pathname.startsWith('/api')) return
+
+  let slug: string | null = null
+
+  // Strategy 1: explicit .md suffix
+  if (pathname.endsWith('.md') && pathname !== '/llms.txt' && pathname !== '/llms-full.txt') {
+    slug = pathname.replace(/\.md$/, '')
+  }
+
+  // Strategy 2: Accept header negotiation
+  if (!slug) {
+    const accept = getHeader(event, 'accept') || ''
+    if (isMarkdownPreferred(accept)) {
+      slug = pathname.replace(/\/$/, '') || '/'
+    }
+  }
+
+  if (!slug) return
+
+  const filePath = resolveMarkdownFile(slug)
+  if (!filePath) return
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  return new Response(content, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Content-Source': 'llm-markdown'
+    }
+  })
+})

--- a/server/routes/llms-full.txt.ts
+++ b/server/routes/llms-full.txt.ts
@@ -1,0 +1,62 @@
+import { defineEventHandler } from 'h3'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\n[\s\S]*?\n---\n*/, '')
+}
+
+function extractTitle(content: string): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return ''
+  return match[1].match(/^title:\s*(.+)$/m)?.[1]?.trim() || ''
+}
+
+function walkAndConcat(dir: string, baseUrl: string, relativeTo: string): string[] {
+  const pages: string[] = []
+  if (!fs.existsSync(dir)) return pages
+
+  const items = fs.readdirSync(dir, { withFileTypes: true })
+  for (const item of items) {
+    const fullPath = path.join(dir, item.name)
+    if (item.isDirectory()) {
+      pages.push(...walkAndConcat(fullPath, baseUrl, relativeTo))
+    } else if (item.name.endsWith('.md')) {
+      const raw = fs.readFileSync(fullPath, 'utf-8')
+      const title = extractTitle(raw)
+      if (!title) continue
+
+      const relPath = path.relative(relativeTo, fullPath)
+        .replace(/\.md$/, '')
+        .replace(/\/index$/, '')
+      const url = `${baseUrl}/${relPath}`
+      const body = stripFrontmatter(raw).trim()
+      if (!body || body === '<!-- Menu Mapping -->') continue
+
+      pages.push(`# ${title} (${url})\n\n${body}`)
+    }
+  }
+  return pages
+}
+
+export default defineEventHandler(() => {
+  const contentDir = path.resolve(process.cwd(), 'content')
+
+  const cnPages = walkAndConcat(
+    path.join(contentDir, 'cn'),
+    '/cn',
+    path.join(contentDir, 'cn')
+  )
+  const enPages = walkAndConcat(
+    path.join(contentDir, 'en'),
+    '',
+    path.join(contentDir, 'en')
+  )
+
+  const allPages = [...cnPages, ...enPages]
+  const output = allPages.join('\n\n---\n\n')
+
+  return new Response(output, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+  })
+})

--- a/server/routes/llms.txt.ts
+++ b/server/routes/llms.txt.ts
@@ -1,0 +1,88 @@
+import { defineEventHandler } from 'h3'
+import fs from 'node:fs'
+import path from 'node:path'
+
+interface DocEntry {
+  title: string
+  desc: string
+  url: string
+}
+
+function extractFrontmatter(content: string): { title: string; desc: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return { title: '', desc: '' }
+  const fm = match[1]
+  const title = fm.match(/^title:\s*(.+)$/m)?.[1]?.trim() || ''
+  const desc = fm.match(/^desc:\s*(.+)$/m)?.[1]?.trim() || ''
+  return { title, desc }
+}
+
+function walkMdFiles(dir: string, baseUrl: string, relativeTo: string): DocEntry[] {
+  const entries: DocEntry[] = []
+  if (!fs.existsSync(dir)) return entries
+
+  const items = fs.readdirSync(dir, { withFileTypes: true })
+  for (const item of items) {
+    const fullPath = path.join(dir, item.name)
+    if (item.isDirectory()) {
+      entries.push(...walkMdFiles(fullPath, baseUrl, relativeTo))
+    } else if (item.name.endsWith('.md')) {
+      const content = fs.readFileSync(fullPath, 'utf-8')
+      const { title, desc } = extractFrontmatter(content)
+      if (!title) continue
+
+      const body = content.replace(/^---\n[\s\S]*?\n---\n*/, '').trim()
+      if (!body || body === '<!-- Menu Mapping -->') continue
+
+      const relPath = path.relative(relativeTo, fullPath)
+        .replace(/\.md$/, '')
+        .replace(/\/index$/, '')
+      const url = `${baseUrl}/${relPath}`
+      entries.push({ title, desc, url })
+    }
+  }
+  return entries
+}
+
+export default defineEventHandler(() => {
+  const contentDir = path.resolve(process.cwd(), 'content')
+
+  const cnEntries = walkMdFiles(
+    path.join(contentDir, 'cn'),
+    '/cn',
+    path.join(contentDir, 'cn')
+  )
+  const enEntries = walkMdFiles(
+    path.join(contentDir, 'en'),
+    '',
+    path.join(contentDir, 'en')
+  )
+
+  let output = '# MemOS Documentation\n\n'
+  output += '> MemOS is a long-term memory system for AI agents and applications.\n'
+  output += '> To get raw Markdown of any page, append .md to its URL or request with Accept: text/markdown header.\n'
+  output += '> Full documentation text: /llms-full.txt\n\n'
+
+  if (cnEntries.length) {
+    output += '## 中文文档\n\n'
+    for (const entry of cnEntries) {
+      output += `- [${entry.title}](${entry.url})`
+      if (entry.desc) output += `: ${entry.desc}`
+      output += '\n'
+    }
+    output += '\n'
+  }
+
+  if (enEntries.length) {
+    output += '## English Documentation\n\n'
+    for (const entry of enEntries) {
+      output += `- [${entry.title}](${entry.url})`
+      if (entry.desc) output += `: ${entry.desc}`
+      output += '\n'
+    }
+  }
+
+  return new Response(output, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+  })
+})


### PR DESCRIPTION
Summary:
- Add /llms.txt and /llms-full.txt routes for agent-readable docs.
- Prerender llms files and export source Markdown into static output during publish.
- Support direct .md and Accept: text/markdown responses for server deployments.

Validation:
- pnpm run publish
- Static preview returned 200 for /llms.txt, /cn/memos_cloud/getting_started/overview.md, and /memos_cloud/getting_started/overview.md