### PR TITLE
fix: restore content search groups

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -9,6 +9,13 @@ const switchLocalePath = useSwitchLocalePath()
 const normalizedPath = computed(() => switchLocalePath(defaultLocale))
 const contentNavigation = useContentNavigation(locale)
 
+const searchNavigation = computed(() => {
+  return (contentNavigation.value || []).map((item, index) => ({
+    ...item,
+    path: item.path || `search-group-${index}`
+  }))
+})
+
 const normalizePath = (p: string) => p.replace(/\/$/, '')
 
 const getSegment = (p: string) => {
@@ -152,7 +159,7 @@ provide('navigation', filteredNavigation)
     <ClientOnly>
       <LazyUContentSearch
         :files="processedFiles"
-        :navigation="contentNavigation"
+        :navigation="searchNavigation"
       />
       <ApiKeyPickerHost />
     </ClientOnly>


### PR DESCRIPTION
Summary:
- Give top-level content search navigation groups stable internal ids.
- Fix empty search modal where only Theme commands were shown.

Root cause:
- UContentSearch maps navigation groups using group.path as CommandPalette group id.
- Our top-level navigation groups are section headings without path, so CommandPalette dropped those groups and only kept Theme.

Validation:
- pnpm run publish
- Static preview confirmed search index loads and document groups/results render for /cn/.