### PR TITLE
docs: sync DingTalk release plan v2.0.23

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,32 @@
 versions:
+  - name: v2.0.23
+    date: '2026-07-09'
+    products:
+      cloud:
+        Improvements:
+          - type: 偏好记忆模型调用
+            changedInfo:
+              - 兼容qwen3系混合思考模型，默认把thinking关掉
+      plugin:
+        New Features:
+          - type: 新增本地记忆数据导出
+            changedInfo:
+              - 支持自动召回 Phase 1 检索参数配置
+              - 支持中文关键词分词配置
+              - 新增 L3 抽象专用模型配置。
+        Improvements:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - 优化插件启动/注册链路
+              - 优化 embedding 输入按用途路由
+              - 轻量记忆模式下减少不必要的后台演化调用
+              - 补充中文 README 和使用说明。
+        Bug Fixes:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - 修复大数据量场景下向量扫描导致 CPU 100% 的问题
+              - 修复 SQLite native binding 版本不匹配恢复问题
+              - 修复 Hermes provider 链接、OpenAI-compatible endpoint 探测、FTS 查询转义、插件入口发布等稳定性问题。
   - name: v2.0.22
     date: '2026-07-03'
     products:
@@ -691,7 +719,6 @@ versions:
           changedInfo:
             - 修复通用文本记忆处理逻辑
             - 修复memreader组件问题
-
   - name: v0.2.1
     date: 2025-07-21
     changedInfo:
@@ -719,7 +746,6 @@ versions:
           changedInfo:
             - 新增Cookbook内容
             - 新增Mud游戏示例
-
   - name: v0.2.0
     date: 2025-07-11
     changedInfo:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,32 @@
 versions:
+  - name: v2.0.23
+    date: '2026-07-09'
+    products:
+      cloud:
+        Improvements:
+          - type: 偏好记忆模型调用
+            changedInfo:
+              - 兼容qwen3系混合思考模型，默认把thinking关掉
+      plugin:
+        New Features:
+          - type: 新增本地记忆数据导出
+            changedInfo:
+              - Supports automatic recall Phase 1 检索参数配置
+              - Supports 中文关键词分词配置
+              - Added L3 抽象专用模型配置。
+        Improvements:
+          - type: OpenClaw local plugin
+            changedInfo:
+              - Improved 插件启动/注册链路
+              - Improved embedding 输入按用途路由
+              - 轻量记忆模式下减少不必要的后台演化调用
+              - Added 中文 README 和使用说明。
+        Bug Fixes:
+          - type: OpenClaw local plugin
+            changedInfo:
+              - Fixed 大数据量场景下向量扫描导致 CPU 100% 的问题
+              - Fixed SQLite native binding 版本不匹配恢复问题
+              - Fixed Hermes provider 链接、OpenAI-compatible endpoint 探测、FTS 查询转义、插件入口发布等稳定性问题。
   - name: v2.0.22
     date: '2026-07-03'
     products:
@@ -679,7 +707,6 @@ versions:
           changedInfo:
             - Fixed general text memory processing logic
             - Fixed memreader component issues
-
   - name: v0.2.1
     date: 2025-07-21
     changedInfo:
@@ -707,7 +734,6 @@ versions:
           changedInfo:
             - Added new Cookbook content
             - Included Mud game example
-
   - name: v0.2.0
     date: 2025-07-11
     changedInfo:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.23`
- Publisher: 项方伟
- Published at: 2025-07-09
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/PwkYGxZV3ZnByQAns9Ar2Eg6WAgozOKL?utm_scene=team_space

## Edits
- OK `content/cn/changelog.yml` (line_replace/memos_docs_changelog_yml): inserted version v2.0.23
- OK `content/en/changelog.yml` (line_replace/memos_docs_changelog_yml_en): inserted version v2.0.23

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.