### PR TITLE
docs: move plugin release changelog to Plugin tab

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,26 +1,4 @@
 versions:
-  - name: v2.0.10
-    date: '2026-07-15'
-    products:
-      plugin:
-        New Features:
-          - type: OpenClaw 本地插件
-            changedInfo:
-              - '**轻量记忆模式配置**：支持通过配置控制记忆演化流程，便于在轻量场景下降低后台处理开销'
-              - '**L3 抽象模型配置**：新增专用的 L3 LLM 配置入口，用于独立管理抽象总结阶段的模型调用'
-              - '**中文关键词召回支持**：增强 CJK 关键词分词能力，提升中文内容的检索与召回效果'
-        Improvements:
-          - type: OpenClaw 本地插件
-            changedInfo:
-              - '**向量扫描性能优化**：重构大数据量下的向量读取与批处理逻辑，降低同步全表扫描导致的 CPU 压力'
-              - '**检索上下文边界优化**：使用更清晰的 XML 边界组织记忆上下文，降低模型误读上下文的概率'
-              - '**Hermes 集成稳定性增强**：改进 provider 启动等待、链接管理和安装脚本，提升本地插件与 Hermes 的兼容性'
-        Bug Fixes:
-          - type: OpenClaw 本地插件
-            changedInfo:
-              - '**轻量记忆模式不生效**：修复 `algorithm.lightweightMemory.enabled=true` 时仍可能触发演化流水线的问题'
-              - '**OpenAI-compatible endpoint 探测异常**：修复完整 endpoint 路径下 provider 探测不稳定的问题'
-              - '**记忆恢复与采集边界问题**：修复脏数据恢复、孤立 trace 写入和 LLM 空响应重试等稳定性问题'
   - name: v2.0.23
     date: '2026-07-09'
     products:

--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,26 @@
 versions:
+  - name: v2.0.10
+    date: '2026-07-15'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**轻量记忆模式配置**：支持通过配置控制记忆演化流程，便于在轻量场景下降低后台处理开销。'
+              - '**L3 抽象模型配置**：新增专用的 L3 LLM 配置入口，用于独立管理抽象总结阶段的模型调用。'
+              - '**中文关键词召回支持**：增强 CJK 关键词分词能力，提升中文内容的检索与召回效果。'
+        Improvements:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**向量扫描性能优化**：重构大数据量下的向量读取与批处理逻辑，降低同步全表扫描导致的 CPU 压力。'
+              - '**检索上下文边界优化**：使用更清晰的 XML 边界组织记忆上下文，降低模型误读上下文的概率。'
+              - '**Hermes 集成稳定性增强**：改进 provider 启动等待、链接管理和安装脚本，提升本地插件与 Hermes 的兼容性。'
+        Bug Fixes:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**轻量记忆模式不生效**：修复 `algorithm.lightweightMemory.enabled=true` 时仍可能触发演化流水线的问题。'
+              - '**OpenAI-compatible endpoint 探测异常**：修复完整 endpoint 路径下 provider 探测不稳定的问题。'
+              - '**记忆恢复与采集边界问题**：修复脏数据恢复、孤立 trace 写入和 LLM 空响应重试等稳定性问题。'
   - name: v0.1.19
     date: '2026-07-07'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,26 +1,4 @@
 versions:
-  - name: v2.0.10
-    date: '2026-07-15'
-    products:
-      plugin:
-        New Features:
-          - type: OpenClaw Local Plugin
-            changedInfo:
-              - 'Added **lightweight memory mode configuration**: allows control of the memory evolution process through configuration to reduce backend processing overhead in lightweight scenarios'
-              - 'Added **L3 abstract model configuration**: a dedicated entry for L3 LLM configuration to independently manage model calls during the abstract summarization phase'
-              - 'Enhanced **Chinese keyword recall support**: improves the retrieval and recall of Chinese content'
-        Improvements:
-          - type: OpenClaw Local Plugin
-            changedInfo:
-              - '**Vector scanning performance optimization**: refactored vector reading and batch processing logic under large data volumes to reduce CPU pressure caused by synchronous full table scans'
-              - '**Retrieval context boundary optimization**: organized memory context using clearer XML boundaries to reduce the probability of the model misreading the context'
-              - '**Hermes integration stability enhancement**: improved provider startup waiting, link management, and installation scripts to enhance compatibility between the local plugin and Hermes'
-        Bug Fixes:
-          - type: OpenClaw Local Plugin
-            changedInfo:
-              - 'Fixed **lightweight memory mode not working**: resolved the issue where the evolution pipeline could still be triggered when `algorithm.lightweightMemory.enabled=true`'
-              - 'Fixed **OpenAI-compatible endpoint detection anomaly**: resolved the instability issue with provider detection under the complete endpoint path'
-              - 'Fixed **memory recovery and collection boundary issues**: addressed stability issues related to dirty data recovery, isolated trace writing, and LLM empty response retries'
   - name: v2.0.23
     date: '2026-07-09'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,26 @@
 versions:
+  - name: v2.0.10
+    date: '2026-07-15'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Lightweight memory mode configuration**: controls the memory evolution process through configuration to reduce backend processing overhead in lightweight scenarios.'
+              - '**L3 abstract model configuration**: adds a dedicated L3 LLM configuration entry for the abstract summarization stage.'
+              - '**Chinese keyword recall support**: improves tokenization for CJK keywords and strengthens Chinese retrieval and recall.'
+        Improvements:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Vector scanning performance**: refactors vector reading and batch processing for large datasets to reduce CPU pressure from synchronous full-table scans.'
+              - '**Retrieval context boundaries**: uses clearer XML boundaries for memory context to reduce model misreading.'
+              - '**Hermes integration stability**: improves provider startup waiting, link management, and installation scripts for better local plugin compatibility.'
+        Bug Fixes:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Lightweight memory mode activation**: fixes cases where the evolution pipeline could still run when `algorithm.lightweightMemory.enabled=true`.'
+              - '**OpenAI-compatible endpoint probing**: fixes unstable provider detection when a full endpoint path is configured.'
+              - '**Memory recovery and collection boundaries**: fixes dirty-data recovery, isolated trace writes, and empty LLM response retry stability issues.'
   - name: v0.1.19
     date: '2026-07-07'
     products:


### PR DESCRIPTION
## 变更说明

修复本地插件独立 Release 写入错误位置的问题：

- 从 `content/cn/changelog.yml` / `content/en/changelog.yml` 移除 `OpenClaw 本地插件 v2.0.10` 独立 release 条目
- 将该条目迁入 `content/cn/plugin-changelog.yml` / `content/en/plugin-changelog.yml`
- 保持 `Highlight` 只展示钉钉周发布文档提取内容
- `Plugin` tab 继续承载本地插件、云插件、CLI 的独立 release 内容

## 验证

- YAML 解析通过
- 106 Doc Agent renderer dry-run 已确认后续本地插件 release 只写 `plugin-changelog.yml`
- `nuxt typecheck` 因仓库既有 TS 类型问题失败，非本 PR 引入

## 部署边界

只允许触发预发和灰度，不触发生产。
