### PR TITLE
docs: sync DingTalk release plan v2.0.24

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -9,29 +9,33 @@ versions:
               - 属性树
               - 事件记忆
               - 多视角
-      playground:
-        New Features:
-          - type: 上线「属性树」
+          - type: 属性树
             changedInfo:
               - 支持模板管理、实例绑定、字段编辑及实例删除
-          - type: 上线「事件记忆」
+          - type: 事件记忆
             changedInfo:
               - 支持事件提取、检索、展示、更新及删除
-          - type: Playground
+          - type: 事件记忆抽取配置
             changedInfo:
               - 新增事件记忆抽取配置，支持 Prompt 编辑、AI 优化、恢复默认和调试运行
+          - type: Agent 多视角
+            changedInfo:
               - 新增 Agent 多视角，支持为不同用户和 Agent 独立生产、更新与召回记忆
         Improvements:
-          - type: Playground
+          - type: 记忆列表
             changedInfo:
-              - 记忆列表新增属性树和事件记忆展示
+              - 新增属性树和事件记忆展示
+          - type: 云服务控制台
+            changedInfo:
               - 核心记忆接口全面适配多视角，支持按记忆视图限定生产和检索范围
               - 记忆检索支持多视图混排、统一重排及 related_id 范围过滤
               - 支持多人、多 Agent 对话场景
               - 优化异步任务的记忆变更结果查询
-              - 调用日志新增用户与 Agent 信息，并适配属性树、事件记忆的变更记录
+          - type: 调用日志
+            changedInfo:
+              - 新增用户与 Agent 信息，并适配属性树、事件记忆的变更记录
         Bug Fixes:
-          - type: Playground
+          - type: 云服务控制台
             changedInfo:
               - 修复知识库详情返回的关联项目 ID 不准确的问题
               - 修复 OpenMem 接口导入的消息误入本地聊天历史的问题

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -9,29 +9,33 @@ versions:
               - Property Tree
               - Event Memory
               - Multi-view
-      playground:
-        New Features:
           - type: Property Tree
             changedInfo:
               - Supports template management, instance binding, field editing, and instance deletion
           - type: Event Memory
             changedInfo:
               - Supports event extraction, retrieval, display, update, and deletion
-          - type: Playground
+          - type: Event Memory extraction configuration
             changedInfo:
               - Added Event Memory extraction configuration with prompt editing, AI optimization, restore defaults, and debug runs
+          - type: Agent multi-view
+            changedInfo:
               - Added Agent multi-view support for independent memory generation, update, and recall by user and Agent
         Improvements:
-          - type: Playground
+          - type: Memory list
             changedInfo:
-              - Added Property Tree and Event Memory display to the memory list
+              - Added Property Tree and Event Memory display
+          - type: Cloud Playground
+            changedInfo:
               - Updated core memory APIs for multi-view and supports scoping generation and retrieval by memory view
               - Memory retrieval supports mixed multi-view results, unified reranking, and related_id range filtering
               - Supports multi-user and multi-Agent conversations
               - Optimized querying memory-change results for async tasks
-              - Added user and Agent information to call logs and adapted change records for Property Tree and Event Memory
+          - type: Call logs
+            changedInfo:
+              - Added user and Agent information, and adapted change records for Property Tree and Event Memory
         Bug Fixes:
-          - type: Playground
+          - type: Cloud Playground
             changedInfo:
               - Fixed inaccurate related project IDs returned by knowledge-base details
               - Fixed messages imported through the OpenMem API being incorrectly written into local chat history


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.24`
- Publisher: 宗玥
- Published at: 2026-07-16
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/LeBq413JAwD1evADT3QG1GBEWDOnGvpb?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.24
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.24.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): updated version v2.0.24
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): updated version v2.0.24

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.