### PR TITLE
docs: sync DingTalk release plan v2.0.25

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,15 @@
 versions:
+  - name: v2.0.25
+    date: '2026-07-23'
+    products:
+      cloud:
+        Bug Fixes:
+          - type: 云服务
+            changedInfo:
+              - 重写dockerfile以解决ack部署问题
+          - type: 事件记忆
+            changedInfo:
+              - 修复事件记忆未截断导致模型输入过长报错问题
   - name: v2.0.24
     date: '2026-07-16'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,15 @@
 versions:
+  - name: v2.0.25
+    date: '2026-07-23'
+    products:
+      cloud:
+        Bug Fixes:
+          - type: Cloud service
+            changedInfo:
+              - Rewrote the Dockerfile to resolve ACK deployment issues.
+          - type: Event Memory
+            changedInfo:
+              - Fixed an issue where Event Memory was not truncated, causing errors due to overly long model inputs.
   - name: v2.0.24
     date: '2026-07-16'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.25`
- Publisher: 翁祺
- Published at: 2026-07-23
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/wva2dxOW4YreyQ6rIkAkyNpLVbkz3BRL?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.25
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.25.post

## Edits
- OK `content/cn/changelog.yml` (line_replace/memos_docs_changelog_yml): inserted version v2.0.25
- OK `content/en/changelog.yml` (line_replace/memos_docs_changelog_yml_en): inserted version v2.0.25

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.