### PR TITLE
docs: sync DingTalk release plan v2.0.25

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -4,12 +4,37 @@ versions:
     products:
       cloud:
         Bug Fixes:
-          - type: 云服务
+          - type: ACK 部署
             changedInfo:
               - 重写dockerfile以解决ack部署问题
           - type: 事件记忆
             changedInfo:
               - 修复事件记忆未截断导致模型输入过长报错问题
+      opensource:
+        Improvements:
+          - type: PolarDB 交互
+            changedInfo:
+              - 优化PolarDB交互，增加return_fields参数，并令其直接影响SQL查询而非在结果层面做裁剪
+              - 通过 search_by_embedding 获取构造MemoryItem的所有必要字段，避免二次调用 get_nodes，节省一次round trip的时延
+          - type: 结果日志
+            changedInfo:
+              - 精简原流程中打印完整结果的日志，改为结果摘要，减少序列化成本
+          - type: MMR 优化
+            changedInfo:
+              - MMR优化：对MMR候选进行剪枝，减少相似度矩阵计算时延
+        Bug Fixes:
+          - type: feedback 模型解析
+            changedInfo:
+              - 修复feedback中模型解析失败问题
+          - type: 模型配置项
+            changedInfo:
+              - 统一简化模型相关配置项
+          - type: embedder 日志
+            changedInfo:
+              - embedder日志问题修复
+          - type: SDK get_task_status
+            changedInfo:
+              - 修复 SDK get_task_status() 无法解析旧版任务状态响应的问题
   - name: v2.0.24
     date: '2026-07-16'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -4,12 +4,37 @@ versions:
     products:
       cloud:
         Bug Fixes:
-          - type: Cloud service
+          - type: ACK deployment
             changedInfo:
-              - Rewrote the Dockerfile to resolve ACK deployment issues.
+              - Rewrote the Dockerfile to resolve ACK deployment issues
           - type: Event Memory
             changedInfo:
-              - Fixed an issue where Event Memory was not truncated, causing errors due to overly long model inputs.
+              - Fixed overlong model inputs caused by Event Memory content not being truncated
+      opensource:
+        Improvements:
+          - type: PolarDB interaction
+            changedInfo:
+              - Optimized PolarDB interaction by adding the return_fields parameter and applying it directly to SQL queries instead of trimming fields only in the result layer
+              - Uses search_by_embedding to fetch all fields required for MemoryItem construction, avoiding an extra get_nodes call and saving one round trip
+          - type: Result logging
+            changedInfo:
+              - Reduced serialization cost by replacing full-result logs in the original flow with result summaries
+          - type: MMR optimization
+            changedInfo:
+              - Optimized MMR by pruning candidates and reducing similarity-matrix computation latency
+        Bug Fixes:
+          - type: Feedback model parsing
+            changedInfo:
+              - Fixed model parsing failures in feedback processing
+          - type: Model configuration
+            changedInfo:
+              - Unified and simplified model-related configuration options
+          - type: Embedder logs
+            changedInfo:
+              - Fixed embedder logging issues
+          - type: SDK get_task_status
+            changedInfo:
+              - Fixed SDK get_task_status() parsing for legacy task-status responses
   - name: v2.0.24
     date: '2026-07-16'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.25`
- Publisher: 翁祺
- Published at: 2026-07-23
- Target repo: `MemTensor/MemOS-Docs`
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.25
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.25.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): updated version v2.0.25
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): updated version v2.0.25

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.