### PR TITLE
docs: changelog for OpenClaw 本地插件 v2.0.11

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,16 @@
 versions:
+  - name: v2.0.11
+    date: '2026-07-27'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**批量反射评分功能**：新增批量反射评分功能以优化性能'
+        Bug Fixes:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**修复 V7 会话默认设置**：确保 V7 会话的默认设置在插件中得以保留'
   - name: v2.0.10
     date: '2026-07-15'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,16 @@
 versions:
+  - name: v2.0.11
+    date: '2026-07-27'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Chunk batch reflection scoring**: Introduced chunk batch reflection scoring feature for performance optimization'
+        Bug Fixes:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Fix V7 session defaults**: Ensure V7 session defaults are preserved in the plugin'
   - name: v2.0.10
     date: '2026-07-15'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [memos-local-plugin-v2.0.11](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.11).

- Source: `MemTensor/MemOS`
- Plugin: `OpenClaw 本地插件`
- Version: `v2.0.11`
- Date: `2026-07-27`
- Mapping id: `openclaw-local-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **Draft PR**，请 review 后 merge。如需修订翻译/分类，可以在本 PR 上直接 commit 修改后再 merge。