### PR TITLE
docs: remove noisy v2.0.25 changelog entries

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -4,21 +4,11 @@ versions:
     products:
       cloud:
         Bug Fixes:
-          - type: ACK 部署
-            changedInfo:
-              - 重写dockerfile以解决ack部署问题
           - type: 事件记忆
             changedInfo:
               - 修复事件记忆未截断导致模型输入过长报错问题
       opensource:
         Improvements:
-          - type: PolarDB 交互
-            changedInfo:
-              - 优化PolarDB交互，增加return_fields参数，并令其直接影响SQL查询而非在结果层面做裁剪
-              - 通过 search_by_embedding 获取构造MemoryItem的所有必要字段，避免二次调用 get_nodes，节省一次round trip的时延
-          - type: 结果日志
-            changedInfo:
-              - 精简原流程中打印完整结果的日志，改为结果摘要，减少序列化成本
           - type: MMR 优化
             changedInfo:
               - MMR优化：对MMR候选进行剪枝，减少相似度矩阵计算时延

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -4,21 +4,11 @@ versions:
     products:
       cloud:
         Bug Fixes:
-          - type: ACK deployment
-            changedInfo:
-              - Rewrote the Dockerfile to resolve ACK deployment issues
           - type: Event Memory
             changedInfo:
               - Fixed overlong model inputs caused by Event Memory content not being truncated
       opensource:
         Improvements:
-          - type: PolarDB interaction
-            changedInfo:
-              - Optimized PolarDB interaction by adding the return_fields parameter and applying it directly to SQL queries instead of trimming fields only in the result layer
-              - Uses search_by_embedding to fetch all fields required for MemoryItem construction, avoiding an extra get_nodes call and saving one round trip
-          - type: Result logging
-            changedInfo:
-              - Reduced serialization cost by replacing full-result logs in the original flow with result summaries
           - type: MMR optimization
             changedInfo:
               - Optimized MMR by pruning candidates and reducing similarity-matrix computation latency


### PR DESCRIPTION
## Summary

Remove the v2.0.25 changelog entries marked for deletion in the Highlight tab:

- remove the `ACK 部署` bug-fix item under 云服务
- remove the `PolarDB 交互` improvement item under 开源项目
- remove the `结果日志` improvement item under 开源项目

The remaining v2.0.25 entries, including Event Memory, MMR optimization, and the existing bug-fix items, are preserved.

## Validation

- Parsed both `content/cn/changelog.yml` and `content/en/changelog.yml`
- Ran local preview at `http://127.0.0.1:4335/cn/changelog/`
- Confirmed the removed markers are absent from the page text

## Deployment boundary

After merge, only pre and gray should be triggered. Production must remain manual.