### PR TITLE
docs: changelog for OpenClaw 本地插件 v2.0.12

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v2.0.12
+    date: '2026-07-29'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**版本更新**：发布 OpenClaw 本地插件 v2.0.12'
   - name: v2.0.10
     date: '2026-07-15'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v2.0.12
+    date: '2026-07-29'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Version Update**: Released OpenClaw Local Plugin v2.0.12'
   - name: v2.0.10
     date: '2026-07-15'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [memos-local-plugin-v2.0.12](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.12).

- Source: `MemTensor/MemOS`
- Plugin: `OpenClaw 本地插件`
- Version: `v2.0.12`
- Date: `2026-07-29`
- Mapping id: `openclaw-local-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **Draft PR**，请 review 后 merge。如需修订翻译/分类，可以在本 PR 上直接 commit 修改后再 merge。