### PR TITLE
docs: backfill OpenClaw local plugin changelog

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,26 @@
 versions:
+  - name: v2.0.12
+    date: '2026-07-29'
+    products:
+      plugin:
+        Improvements:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**Hermes 共享桥接运行时**：多个 Hermes provider 复用同一 Node bridge，并按 data home 隔离状态，减少重复启动和会话串扰。'
+              - '**Hermes 版本元数据同步**：安装时同步 plugin.yaml 与包版本，确保宿主展示的本地插件版本一致。'
+        Bug Fixes:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**Hermes 配置重载与恢复**：重启后重新加载配置并强化恢复生命周期，降低桥接异常后的恢复失败风险。'
+              - '**压缩阶段只读保护**：保持 Hermes compression turn 只读，避免压缩流程意外写入会话状态。'
+  - name: v2.0.11
+    date: '2026-07-27'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: OpenClaw 本地插件
+            changedInfo:
+              - '**V7 会话默认配置**：保留默认 session 参数，仅覆盖 follow-up mode，避免 V7 会话链路丢失默认行为。'
   - name: v2.0.10
     date: '2026-07-15'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,26 @@
 versions:
+  - name: v2.0.12
+    date: '2026-07-29'
+    products:
+      plugin:
+        Improvements:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Shared Hermes bridge runtime**: Reuses one Node bridge across Hermes providers while isolating state by data home to reduce duplicate startups and session bleed.'
+              - '**Hermes version metadata**: Syncs plugin.yaml with the package version during install so hosts display the correct local plugin version.'
+        Bug Fixes:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**Hermes config reload and recovery**: Reloads config after restart and hardens recovery lifecycle to reduce bridge recovery failures.'
+              - '**Read-only compression turns**: Keeps Hermes compression turns read-only to prevent compression from mutating session state.'
+  - name: v2.0.11
+    date: '2026-07-27'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: OpenClaw Local Plugin
+            changedInfo:
+              - '**V7 session defaults**: Preserves default session parameters while overriding follow-up mode so V7 flows keep their expected behavior.'
   - name: v2.0.10
     date: '2026-07-15'
     products:


### PR DESCRIPTION
## Summary

Manual backfill for the OpenClaw local plugin Plugin tab changelog.

This PR intentionally does not use the legacy standalone `memos-local-plugin-v*` release webhook path. The current production mapping now treats OpenClaw local plugin docs as a MemOS whole-repo release source (`MemTensor/MemOS` + `v*`) and extracts only `apps/memos-local-plugin/**`.

## Evidence

- `v2.0.11`
  - Valid source refs: `d48d2a1a`, `#2158`
  - Kept: V7 session default preservation.
  - Excluded: `21a27ed1` / `#1957`, because `6734a0ea` / `#2145` explicitly reverted it.
- `v2.0.12`
  - Valid source refs: `92653cd8`, `#2184`
  - Kept: Hermes shared bridge runtime, Hermes version metadata sync, Hermes config reload/recovery, read-only compression turns.
  - Excluded: release metadata-only changes and Python lint-only changes.

## Safety

- Only changes:
  - `content/cn/plugin-changelog.yml`
  - `content/en/plugin-changelog.yml`
- No npm publish.
- No OSS upload.
- No production deployment.
- No secret/token/key values in code, PR body, or changelog files.

## Quality Checks

- YAML parses successfully for both zh/en changelog files.
- New entries are limited to 5 bullets total.
- Chinese entries are non-empty and under 180 characters each.
- English entries contain no Chinese text and are under 220 characters each.
- Wrong legacy phrases are absent: `批量反射评分`, `版本更新`, `chunk batch reflection`.
