### PR TITLE
docs: rename local plugin changelog title

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -4,12 +4,12 @@ versions:
     products:
       plugin:
         Improvements:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**Hermes 共享桥接运行时**：多个 Hermes provider 复用同一 Node bridge，并按 data home 隔离状态，减少重复启动和会话串扰。'
               - '**Hermes 版本元数据同步**：安装时同步 plugin.yaml 与包版本，确保宿主展示的本地插件版本一致。'
         Bug Fixes:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**Hermes 配置重载与恢复**：重启后重新加载配置并强化恢复生命周期，降低桥接异常后的恢复失败风险。'
               - '**压缩阶段只读保护**：保持 Hermes compression turn 只读，避免压缩流程意外写入会话状态。'
@@ -18,7 +18,7 @@ versions:
     products:
       plugin:
         Bug Fixes:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**V7 会话默认配置**：保留默认 session 参数，仅覆盖 follow-up mode，避免 V7 会话链路丢失默认行为。'
   - name: v2.0.10
@@ -26,19 +26,19 @@ versions:
     products:
       plugin:
         New Features:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**轻量记忆模式配置**：支持通过配置控制记忆演化流程，便于在轻量场景下降低后台处理开销。'
               - '**L3 抽象模型配置**：新增专用的 L3 LLM 配置入口，用于独立管理抽象总结阶段的模型调用。'
               - '**中文关键词召回支持**：增强 CJK 关键词分词能力，提升中文内容的检索与召回效果。'
         Improvements:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**向量扫描性能优化**：重构大数据量下的向量读取与批处理逻辑，降低同步全表扫描导致的 CPU 压力。'
               - '**检索上下文边界优化**：使用更清晰的 XML 边界组织记忆上下文，降低模型误读上下文的概率。'
               - '**Hermes 集成稳定性增强**：改进 provider 启动等待、链接管理和安装脚本，提升本地插件与 Hermes 的兼容性。'
         Bug Fixes:
-          - type: OpenClaw 本地插件
+          - type: MemOS 本地插件
             changedInfo:
               - '**轻量记忆模式不生效**：修复 `algorithm.lightweightMemory.enabled=true` 时仍可能触发演化流水线的问题。'
               - '**OpenAI-compatible endpoint 探测异常**：修复完整 endpoint 路径下 provider 探测不稳定的问题。'

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -4,12 +4,12 @@ versions:
     products:
       plugin:
         Improvements:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**Shared Hermes bridge runtime**: Reuses one Node bridge across Hermes providers while isolating state by data home to reduce duplicate startups and session bleed.'
               - '**Hermes version metadata**: Syncs plugin.yaml with the package version during install so hosts display the correct local plugin version.'
         Bug Fixes:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**Hermes config reload and recovery**: Reloads config after restart and hardens recovery lifecycle to reduce bridge recovery failures.'
               - '**Read-only compression turns**: Keeps Hermes compression turns read-only to prevent compression from mutating session state.'
@@ -18,7 +18,7 @@ versions:
     products:
       plugin:
         Bug Fixes:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**V7 session defaults**: Preserves default session parameters while overriding follow-up mode so V7 flows keep their expected behavior.'
   - name: v2.0.10
@@ -26,19 +26,19 @@ versions:
     products:
       plugin:
         New Features:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**Lightweight memory mode configuration**: controls the memory evolution process through configuration to reduce backend processing overhead in lightweight scenarios.'
               - '**L3 abstract model configuration**: adds a dedicated L3 LLM configuration entry for the abstract summarization stage.'
               - '**Chinese keyword recall support**: improves tokenization for CJK keywords and strengthens Chinese retrieval and recall.'
         Improvements:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**Vector scanning performance**: refactors vector reading and batch processing for large datasets to reduce CPU pressure from synchronous full-table scans.'
               - '**Retrieval context boundaries**: uses clearer XML boundaries for memory context to reduce model misreading.'
               - '**Hermes integration stability**: improves provider startup waiting, link management, and installation scripts for better local plugin compatibility.'
         Bug Fixes:
-          - type: OpenClaw Local Plugin
+          - type: MemOS Local Plugin
             changedInfo:
               - '**Lightweight memory mode activation**: fixes cases where the evolution pipeline could still run when `algorithm.lightweightMemory.enabled=true`.'
               - '**OpenAI-compatible endpoint probing**: fixes unstable provider detection when a full endpoint path is configured.'


### PR DESCRIPTION
## Summary
- Rename the Plugin tab display type for local plugin entries from OpenClaw Local Plugin to MemOS Local Plugin.
- Keep release versions, dates, categories, and changelog bullets unchanged.

## Safety
- No token, endpoint, npm, OSS, or production deployment changes.
- Machine source id remains openclaw-local-plugin; this only changes user-facing display text.

## Validation
- git diff --check
- Verified cn/en plugin-changelog.yml no longer contain OpenClaw local plugin display types.