### PR TITLE
docs: sync DingTalk release plan v2.0.28

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,20 @@
 versions:
+  - name: v2.0.28
+    date: '2026-07-30'
+    products:
+      cloud:
+        Improvements:
+          - type: 云服务
+            changedInfo:
+              - 删除记忆时缺少路由信息，导致效率低、成本高
+          - type: 云服务控制台
+            changedInfo:
+              - 修改playground system prompt中小忆的角色认知部分
+      opensource:
+        Improvements:
+          - type: 开源项目
+            changedInfo:
+              - 优化MemOS文档抽取，返回模式和截断字符数调整
   - name: v2.0.25
     date: '2026-07-23'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,20 @@
 versions:
+  - name: v2.0.28
+    date: '2026-07-30'
+    products:
+      cloud:
+        Improvements:
+          - type: Cloud service
+            changedInfo:
+              - Missing routing information when deleting memories leads to low efficiency and high costs.
+          - type: Cloud Playground
+            changedInfo:
+              - Modified the role recognition part of Xiao Yi in the playground system prompt.
+      opensource:
+        Improvements:
+          - type: Open Source
+            changedInfo:
+              - Improved MemOS documentation extraction, adjusted return mode and truncation character count.
   - name: v2.0.25
     date: '2026-07-23'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.28`
- Publisher: 魏文强
- Published at: 2026-07-30
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/4lgGw3P8vR9qLnm9cgnebrlP85daZ90D?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.28
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.28.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): inserted version v2.0.28
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): inserted version v2.0.28

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.