### PR TITLE
docs: refine v2.0.28 changelog copy

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -6,10 +6,7 @@ versions:
         Improvements:
           - type: 云服务
             changedInfo:
-              - 删除记忆时缺少路由信息，导致效率低、成本高
-          - type: 云服务控制台
-            changedInfo:
-              - 修改playground system prompt中小忆的角色认知部分
+              - 删除记忆时因缺少路由信息，而导致效率低、成本高的问题
       opensource:
         Improvements:
           - type: 开源项目

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -6,10 +6,7 @@ versions:
         Improvements:
           - type: Cloud service
             changedInfo:
-              - Missing routing information when deleting memories leads to low efficiency and high costs.
-          - type: Cloud Playground
-            changedInfo:
-              - Modified the role recognition part of Xiao Yi in the playground system prompt.
+              - Resolved low efficiency and high costs caused by missing routing information when deleting memories.
       opensource:
         Improvements:
           - type: Open Source


### PR DESCRIPTION
按产品经理反馈修订 v2.0.28 更新日志：

- 删除云服务控制台中不需要的 Playground system prompt 条目
- 优化删除记忆路由信息问题的中文表述
- 同步英文文案

已完成 YAML 校验、diff check 与本地 Nuxt 静态构建。自动发布仅允许 pre 和 gray，不触发 production。