### PR TITLE
docs: changelog for OpenClaw 云插件 v0.1.20

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v0.1.20
+    date: '2026-08-03'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw 云插件
+            changedInfo:
+              - '**快照去重功能**：实现了对 agent_end 快照的去重，并增强了 API 调用超时处理'
   - name: v2.0.12
     date: '2026-07-29'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v0.1.20
+    date: '2026-08-03'
+    products:
+      plugin:
+        New Features:
+          - type: OpenClaw Cloud Plugin
+            changedInfo:
+              - '**Snapshot Deduplication**: Implemented deduplication for agent_end snapshots and enhanced API call timeout handling'
   - name: v2.0.12
     date: '2026-07-29'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [v0.1.20](https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin/releases/tag/v0.1.20).

- Source: `MemTensor/MemOS-Cloud-OpenClaw-Plugin`
- Plugin: `OpenClaw 云插件`
- Version: `v0.1.20`
- Date: `2026-08-03`
- Mapping id: `openclaw-cloud-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **Draft PR**，请 review 后 merge。如需修订翻译/分类，可以在本 PR 上直接 commit 修改后再 merge。