### PR TITLE
docs: changelog for MemOS 本地插件 v2.0.13

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,13 @@
 versions:
+  - name: v2.0.13
+    date: '2026-08-05'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS 本地插件
+            changedInfo:
+              - '**前台资源管理修复**：修复了前台资源饥饿问题，并支持 Retry-After 头部'
+              - '**召回相关性改进**：改善了召回相关性和主机输入处理'
   - name: v0.1.20
     date: '2026-08-03'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,13 @@
 versions:
+  - name: v2.0.13
+    date: '2026-08-05'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS Local Plugin
+            changedInfo:
+              - '**Foreground resource management fix**: Prevented foreground starvation and honored Retry-After header'
+              - '**Recall relevance improvement**: Improved recall relevance and host input handling'
   - name: v0.1.20
     date: '2026-08-03'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [memos-local-plugin-v2.0.13](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.13).

- Source: `MemTensor/MemOS`
- Plugin: `MemOS 本地插件`
- Version: `v2.0.13`
- Date: `2026-08-05`
- Mapping id: `openclaw-local-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **Draft PR**，请 review 后 merge。如需修订翻译/分类，可以在本 PR 上直接 commit 修改后再 merge。