### PR TITLE
docs: sync DingTalk release plan v2.0.29

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v2.0.29
+    date: '2026-08-03'
+    products:
+      cloud:
+        Improvements:
+          - type: 记忆列表
+            changedInfo:
+              - 删除记忆时缺少路由信息，优化了 dashboard 记忆列表的删除性能
   - name: v2.0.28
     date: '2026-07-30'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,12 @@
 versions:
+  - name: v2.0.29
+    date: '2026-08-03'
+    products:
+      cloud:
+        Improvements:
+          - type: Memory list
+            changedInfo:
+              - Missing routing information when deleting memories; improved the deletion performance of the dashboard memory list.
   - name: v2.0.28
     date: '2026-07-30'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.29`
- Publisher: 蒋泽宇
- Published at: 2026-08-03
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/X6GRezwJlA0qyjM0tgeapxN18dqbropQ?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.29
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.29.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): inserted version v2.0.29
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): inserted version v2.0.29

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.