### PR TITLE
docs: sync DingTalk release plan v2.0.29

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -4,9 +4,9 @@ versions:
     products:
       cloud:
         Improvements:
-          - type: 记忆列表
+          - type: 云服务控制台
             changedInfo:
-              - 删除记忆时缺少路由信息，优化了 dashboard 记忆列表的删除性能
+              - 优化 Dashboard 记忆列表删除链路，提升目标记忆的定位与删除效率
   - name: v2.0.28
     date: '2026-07-30'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -4,9 +4,9 @@ versions:
     products:
       cloud:
         Improvements:
-          - type: Memory list
+          - type: Cloud Playground
             changedInfo:
-              - Missing routing information when deleting memories; improved the deletion performance of the dashboard memory list.
+              - Optimized the Dashboard memory-list deletion flow to improve locating and deleting target memories
   - name: v2.0.28
     date: '2026-07-30'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.29`
- Publisher: 蒋泽宇
- Published at: 2026-08-03
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/X6GRezwJlA0qyjM0tgeapxN18dqbropQ?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.29
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.29.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): updated version v2.0.29
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): updated version v2.0.29

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.