### PR TITLE
docs: changelog for MemOS 本地插件 v2.0.15

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,15 @@
 versions:
+  - name: v2.0.15
+    date: '2026-08-12'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS 本地插件
+            changedInfo:
+              - '**简单文本分割器修复**：修复了 SimpleTextSplitter 的回退机制，使其 URL 安全，避免了潜在的错误'
+              - '**回退对齐修复**：对齐了回退机制，防止 URL 冲突，确保文本分割的准确性'
+              - '**可选依赖懒加载**：修复了 embedders 中的可选 cachetools 依赖的懒加载问题'
+              - '**Windows 路径修复**：修复了 Hermes 插件在 Windows 上的路径问题，并改善了用户体验'
   - name: v2.0.13
     date: '2026-08-05'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,15 @@
 versions:
+  - name: v2.0.15
+    date: '2026-08-12'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS Local Plugin
+            changedInfo:
+              - '**SimpleTextSplitter Fix**: Fixed the fallback mechanism of SimpleTextSplitter to be URL-safe, preventing potential errors'
+              - '**Fallback Alignment Fix**: Aligned the fallback mechanism to prevent URL collisions, ensuring accurate text splitting'
+              - '**Optional Dependency Lazy Loading**: Fixed the lazy loading issue of the optional cachetools dependency in embedders'
+              - '**Windows Path Fix**: Fixed the path issues for the Hermes plugin on Windows and improved user experience'
   - name: v2.0.13
     date: '2026-08-05'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [memos-local-plugin-v2.0.15](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.15).

- Source: `MemTensor/MemOS`
- Product: `MemOS 本地插件`
- Version: `v2.0.15`
- Date: `2026-08-12`
- Mapping id: `openclaw-local-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **WIP MR**。在 30 分钟冷却期内，任何人都可以 close、request changes 或补充评论；自动合并只会在来源 SHA 未变化、无冲突、无未解决评论、无拒绝评审且必需 CI 全部通过时执行。