### PR TITLE
docs: backfill MemOS Local Plugin v2.0.14 changelog

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -10,6 +10,14 @@ versions:
               - '**回退对齐修复**：对齐了回退机制，防止 URL 冲突，确保文本分割的准确性'
               - '**可选依赖懒加载**：修复了 embedders 中的可选 cachetools 依赖的懒加载问题'
               - '**Windows 路径修复**：修复了 Hermes 插件在 Windows 上的路径问题，并改善了用户体验'
+  - name: v2.0.14
+    date: '2026-08-07'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS 本地插件
+            changedInfo:
+              - '**Windows 运行时生命周期修复**：修复了在 Windows 上的 Hermes 视图守护进程的启动和状态探测问题。'
   - name: v2.0.13
     date: '2026-08-05'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -10,6 +10,14 @@ versions:
               - '**Fallback Alignment Fix**: Aligned the fallback mechanism to prevent URL collisions, ensuring accurate text splitting'
               - '**Optional Dependency Lazy Loading**: Fixed the lazy loading issue of the optional cachetools dependency in embedders'
               - '**Windows Path Fix**: Fixed the path issues for the Hermes plugin on Windows and improved user experience'
+  - name: v2.0.14
+    date: '2026-08-07'
+    products:
+      plugin:
+        Bug Fixes:
+          - type: MemOS Local Plugin
+            changedInfo:
+              - '**Windows runtime lifecycle fix**: Fixed issues with the startup and status probing of the Hermes viewer daemon on Windows.'
   - name: v2.0.13
     date: '2026-08-05'
     products:


### PR DESCRIPTION
## Summary

Backfill the missing bilingual Plugin changelog entry for MemOS Local Plugin v2.0.14.

The package, tag, and GitHub Release were published successfully, but the Doc Agent was still running product release sync in dry-run mode when the original `release.published` webhook and its later redelivery were processed. Both runs validated successfully without creating a MemOS-Docs PR.

## Evidence

- Release: https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.14
- Release workflow: https://github.com/MemTensor/MemOS/actions/runs/31144080123
- Source commit: `8d310a7a`
- Pull request: `MemTensor/MemOS#2230`
- Original quality result: `needs_review=false`, `missing_required_count=0`

## Changes

- Add the v2.0.14 entry to `content/cn/plugin-changelog.yml`.
- Add the matching English entry to `content/en/plugin-changelog.yml`.
- Preserve chronological ordering between v2.0.15 and v2.0.13.

## Validation

- YAML parsing passed for both files.
- Duplicate-version and ordering checks passed.
- `git diff --check` passed.

This is a historical docs backfill only. It does not republish npm, recreate a tag or Release, or require another webhook redelivery.