### PR TITLE
docs: sync DingTalk release plan v2.0.30

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -11,6 +11,13 @@ versions:
           - type: 云服务
             changedInfo:
               - 实现每个worker独立异步写入日志
+      opensource:
+        Bug Fixes:
+          - type: 开源项目
+            changedInfo:
+              - 修复 vLLM 流式响应只保留最后一个 chunk，导致回答截断及空流报错的问题
+              - 修复 UniversalAPIEmbedder 忽略 embedding_dims、无法生成指定维度向量的问题，并为不支持该参数的服务提供自动降级
+              - 为 OpenAI-compatible 和 Azure 模型增加 enable_thinking 控制，避免思考内容破坏 JSON 等结构化输出
   - name: v2.0.29
     date: '2026-08-03'
     products:

--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,16 @@
 versions:
+  - name: v2.0.30
+    date: '2026-08-10'
+    products:
+      cloud:
+        New Features:
+          - type: 云服务
+            changedInfo:
+              - 新增接口支持各个记忆视图通过custom_extract_prompt参数自定义抽取prompt
+        Improvements:
+          - type: 云服务
+            changedInfo:
+              - 实现每个worker独立异步写入日志
   - name: v2.0.29
     date: '2026-08-03'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -11,6 +11,13 @@ versions:
           - type: Cloud service
             changedInfo:
               - Implemented independent asynchronous logging for each worker.
+      opensource:
+        Bug Fixes:
+          - type: Open Source
+            changedInfo:
+              - Fixed vLLM streaming responses retaining only the final chunk, which caused truncated answers and errors on empty streams.
+              - Fixed UniversalAPIEmbedder ignoring embedding_dims, enabling requested vector dimensions and automatic fallback for services that do not support the parameter.
+              - Added enable_thinking control for OpenAI-compatible and Azure models to prevent reasoning content from corrupting structured outputs such as JSON.
   - name: v2.0.29
     date: '2026-08-03'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,16 @@
 versions:
+  - name: v2.0.30
+    date: '2026-08-10'
+    products:
+      cloud:
+        New Features:
+          - type: Cloud service
+            changedInfo:
+              - Added an interface to support customizing the extraction prompt for each memory view through the custom_extract_prompt parameter.
+        Improvements:
+          - type: Cloud service
+            changedInfo:
+              - Implemented independent asynchronous logging for each worker.
   - name: v2.0.29
     date: '2026-08-03'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.30`
- Publisher: @贾澄臻
- Published at: 2026-08-10
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/9bN7RYPWdM2YXdO2TKOqePv2VZd1wyK0?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.30
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.30.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): inserted version v2.0.30
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): inserted version v2.0.30

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.