### PR TITLE
docs: sync DingTalk release plan v2.0.31

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -2,21 +2,11 @@ versions:
   - name: v2.0.31
     date: '2026-08-20'
     products:
-      cloud:
-        Improvements:
-          - type: 云服务
-            changedInfo:
-              - 将 Qwen 模型统一切换至 Qwen3.7-Flash，并完成性能与效果验证
-              - 将请求体默认关闭 thinking 的判断从 Qwen3.5/3.6 扩展至 Qwen3 全系列，支持 Qwen3.7 迁移
-        Bug Fixes:
-          - type: 云服务
-            changedInfo:
-              - 修复多视角插件的回退逻辑，非多视角请求可正常回退至通用模型
       opensource:
         Improvements:
           - type: 开源项目
             changedInfo:
-              - 为 Qwen 模型请求补充请求头，以应对突发限流
+              - 千问模型请求添加header参数，以应对突发限流情况
   - name: v2.0.30
     date: '2026-08-10'
     products:

--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -6,7 +6,7 @@ versions:
         Improvements:
           - type: 开源项目
             changedInfo:
-              - 千问模型请求添加header参数，以应对突发限流情况
+              - 为 Qwen 模型请求补充请求头，以应对突发限流
   - name: v2.0.30
     date: '2026-08-10'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -2,21 +2,11 @@ versions:
   - name: v2.0.31
     date: '2026-08-20'
     products:
-      cloud:
-        Improvements:
-          - type: Cloud Service
-            changedInfo:
-              - Standardized Qwen models on Qwen3.7-Flash after performance and quality validation
-              - Extended the default thinking-disable rule from Qwen3.5/3.6 to the full Qwen3 series to support migration to Qwen3.7
-        Bug Fixes:
-          - type: Cloud Service
-            changedInfo:
-              - Fixed fallback handling in the multi-view plugin so non-multi-view requests correctly fall back to the general-purpose model
       opensource:
         Improvements:
-          - type: Open Source
+          - type: Open Source Project
             changedInfo:
-              - Added request headers for Qwen model calls to better handle sudden rate limiting
+              - The Qianwen model request now includes a header parameter to handle sudden rate limiting situations.
   - name: v2.0.30
     date: '2026-08-10'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -4,9 +4,9 @@ versions:
     products:
       opensource:
         Improvements:
-          - type: Open Source Project
+          - type: Open Source
             changedInfo:
-              - The Qianwen model request now includes a header parameter to handle sudden rate limiting situations.
+              - Added request headers for Qwen model calls to better handle sudden rate limiting
   - name: v2.0.30
     date: '2026-08-10'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.31`
- Publisher: 项方伟
- Published at: 2026-08-20
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/7QG4Yx2JpLyA3pXyiq0nOKP4J9dEq3XD?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.31
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.31.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): updated version v2.0.31
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): updated version v2.0.31

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.