### PR TITLE
docs: sync DingTalk release plan v2.0.32

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,17 @@
 versions:
+  - name: v2.0.32
+    date: '2026-08-26'
+    products:
+      cloud:
+        New Features:
+          - type: 云服务
+            changedInfo:
+              - 新增接口支持图像、文档抽取，通过custom_extract_prompt参数自定义抽取prompt
+        Improvements:
+          - type: 云服务控制台
+            changedInfo:
+              - 优化更新对env参数的.md说明文档和样例
+              - 问题推荐和调度器的模型配置方式修正为灵活的模型名配置，不再在代码中固定api_base和api_key，与其他模型配置保持一致
   - name: v2.0.31
     date: '2026-08-20'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,17 @@
 versions:
+  - name: v2.0.32
+    date: '2026-08-26'
+    products:
+      cloud:
+        New Features:
+          - type: Cloud service
+            changedInfo:
+              - Added support for image and document extraction through the custom_extract_prompt parameter.
+        Improvements:
+          - type: Cloud Playground
+            changedInfo:
+              - Improved the documentation and examples for the env parameter in the .md file.
+              - Updated the model configuration method for question recommendation and scheduler to allow flexible model name configuration, no longer hardcoding api_base and api_key in the code, consistent with other model configurations.
   - name: v2.0.31
     date: '2026-08-20'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.32`
- Publisher: 王源
- Published at: 2026-08-26
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/pYLaezmVNenKgaDnFK9bg4AQWrMqPxX6?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.32
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.32.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): inserted version v2.0.32
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): inserted version v2.0.32

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.