### PR TITLE
docs: refine v2.0.32 public changelog

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -6,12 +6,7 @@ versions:
         New Features:
           - type: 云服务
             changedInfo:
-              - 新增接口支持图像、文档抽取，通过custom_extract_prompt参数自定义抽取prompt
-        Improvements:
-          - type: 云服务控制台
-            changedInfo:
-              - 优化更新对env参数的.md说明文档和样例
-              - 问题推荐和调度器的模型配置方式修正为灵活的模型名配置，不再在代码中固定api_base和api_key，与其他模型配置保持一致
+              - 新增图像与文档内容抽取能力，并支持通过自定义提示词调整抽取规则
   - name: v2.0.31
     date: '2026-08-20'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -6,12 +6,7 @@ versions:
         New Features:
           - type: Cloud service
             changedInfo:
-              - Added support for image and document extraction through the custom_extract_prompt parameter.
-        Improvements:
-          - type: Cloud Playground
-            changedInfo:
-              - Improved the documentation and examples for the env parameter in the .md file.
-              - Updated the model configuration method for question recommendation and scheduler to allow flexible model name configuration, no longer hardcoding api_base and api_key in the code, consistent with other model configurations.
+              - Added image and document content extraction, with support for custom prompts to adjust extraction rules.
   - name: v2.0.31
     date: '2026-08-20'
     products:


### PR DESCRIPTION
## 变更说明

- 保留 v2.0.32 面向用户的图像与文档内容抽取能力
- 将中文文案改为更自然的产品表达，并同步英文
- 移除内部文档维护和模型配置实现细节

## 审阅说明

这是供产品人工修改和确认的 Draft PR，暂不自动合并，也不触发预发、灰度或生产。