### PR TITLE
docs: changelog for MemOS 本地插件 v2.0.18

### DIFF
--- a/content/cn/plugin-changelog.yml
+++ b/content/cn/plugin-changelog.yml
@@ -1,4 +1,17 @@
 versions:
+  - name: v2.0.18
+    date: '2026-09-01'
+    products:
+      plugin:
+        Improvements:
+          - type: MemOS 本地插件
+            changedInfo:
+              - '**记忆恢复与采集边界问题**：修复脏数据恢复、孤立 trace 写入和 LLM 空响应重试等稳定性问题'
+        Bug Fixes:
+          - type: MemOS 本地插件
+            changedInfo:
+              - '**记忆恢复与采集边界问题**：修复脏数据恢复、孤立 trace 写入和 LLM 空响应重试等稳定性问题'
+              - '**Hermes 与桥接体验**：合并 Hermes、provider 和桥接链路优化，减少启动和连接过程中的干扰'
   - name: v1.0.8
     date: '2026-08-28'
     products:

--- a/content/en/plugin-changelog.yml
+++ b/content/en/plugin-changelog.yml
@@ -1,4 +1,17 @@
 versions:
+  - name: v2.0.18
+    date: '2026-09-01'
+    products:
+      plugin:
+        Improvements:
+          - type: MemOS Local Plugin
+            changedInfo:
+              - '**Memory Recovery and Capture Boundaries**: Fixed dirty-data recovery, orphan trace writes, and LLM empty-response retry stability issues'
+        Bug Fixes:
+          - type: MemOS Local Plugin
+            changedInfo:
+              - '**Memory Recovery and Capture Boundaries**: Fixed dirty-data recovery, orphan trace writes, and LLM empty-response retry stability issues'
+              - '**Hermes and Bridge Experience**: Combines Hermes, provider, and bridge-flow improvements to reduce startup and connection friction'
   - name: v1.0.8
     date: '2026-08-28'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from [memos-local-plugin-v2.0.18](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.18).

- Source: `MemTensor/MemOS`
- Product: `MemOS 本地插件`
- Version: `v2.0.18`
- Date: `2026-09-01`
- Mapping id: `openclaw-local-plugin`

## Edits
- ✓ `content/cn/plugin-changelog.yml` (full_replace) — ok
- ✓ `content/en/plugin-changelog.yml` (full_replace) — ok

---
> 这是 **WIP MR**。在 30 分钟冷却期内，任何人都可以 close、request changes 或补充评论；自动合并只会在来源 SHA 未变化、无冲突、无未解决评论、无拒绝评审且必需 CI 全部通过时执行。