### PR TITLE
docs: sync DingTalk release plan v2.0.33

### DIFF
--- a/content/cn/changelog.yml
+++ b/content/cn/changelog.yml
@@ -1,4 +1,22 @@
 versions:
+  - name: v2.0.33
+    date: '2026-09-03'
+    products:
+      cloud:
+        Bug Fixes:
+          - type: 云服务
+            changedInfo:
+              - 修复请求参数校验信息中的异常对象无法序列化，导致 422 校验错误被掩盖为 500 服务异常的问题
+              - 修复获取记忆列表接口skill URL返回空，解决metadata.getKey()判断和加密空字符串问题
+      opensource:
+        Improvements:
+          - type: 偏好记忆抽取
+            changedInfo:
+              - 提升偏好记忆抽取的准确性，排除 Agent 输出、工具调用及拼接上下文的干扰，仅根据用户本人表达识别偏好
+        Bug Fixes:
+          - type: 开源项目
+            changedInfo:
+              - 修复add时异步任务失败时，不再清理fast节点
   - name: v2.0.32
     date: '2026-08-26'
     products:

--- a/content/en/changelog.yml
+++ b/content/en/changelog.yml
@@ -1,4 +1,22 @@
 versions:
+  - name: v2.0.33
+    date: '2026-09-03'
+    products:
+      cloud:
+        Bug Fixes:
+          - type: Cloud Service
+            changedInfo:
+              - Fixed the issue where the exception object in the request parameter validation information could not be serialized, causing the 422 validation error to be masked as a 500 service exception.
+              - Fixed the issue where the skill URL returned empty for the memory list interface, resolving the problem with metadata.getKey() judgment and encrypting empty strings.
+      opensource:
+        Improvements:
+          - type: Preference Memory Extraction
+            changedInfo:
+              - Improved the accuracy of preference memory extraction by excluding interference from Agent output, tool calls, and concatenated context, focusing solely on user expressions to identify preferences.
+        Bug Fixes:
+          - type: Open Source Project
+            changedInfo:
+              - Fixed the issue where asynchronous tasks failed during add operations, preventing the cleanup of fast nodes.
   - name: v2.0.32
     date: '2026-08-26'
     products:


### PR DESCRIPTION
Auto-generated by Doc Agent from a DingTalk release-plan document.

- Version: `v2.0.33`
- Publisher: 牛怡珺
- Published at: 2026-09-03
- Target repo: `MemTensor/MemOS-Docs`
- DingTalk document: https://alidocs.dingtalk.com/i/nodes/9E05BDRVQ209N7j0iPwMREPzJ63zgkYA?utm_scene=team_space
- Open-source branch: https://github.com/MemTensor/MemOS/tree/dev-v2.0.33
- Enterprise branch: https://codeup.aliyun.com/64f72724a0e1e06b21196925/MemTensor/MemOS-Enterprise/tree/dev-v2.0.33.post

## Edits
- OK `content/cn/changelog.yml` (upsert/memos_docs_changelog_yml): inserted version v2.0.33
- OK `content/en/changelog.yml` (upsert/memos_docs_changelog_yml_en): inserted version v2.0.33

---
> Doc Agent may auto-merge this docs PR after deterministic checks. Preview and grayscale deployment should run after merge; production promotion still requires a human gate.